### PR TITLE
FEAT: ZeroMQ - using safe c-string! ending in Hello example

### DIFF
--- a/Library/ZeroMQ/ZeroMQ-Hello-client.reds
+++ b/Library/ZeroMQ/ZeroMQ-Hello-client.reds
@@ -11,7 +11,7 @@ Red/System [
 	Comment: {
 		This script needs external library, which can be downloaded from this site:
 		http://zeromq.org/area:download
-		(tested with xz-5.2.3-windows\[bin_i686|bin_i686-sse2]\liblzma.dll)
+		(tested with libzmq-v120-mt-4_0_4.dll - renamed to libzmq.dll - on Win10)
 	}
 ]
 

--- a/Library/ZeroMQ/ZeroMQ-Hello-client.reds
+++ b/Library/ZeroMQ/ZeroMQ-Hello-client.reds
@@ -36,19 +36,31 @@ print-line ["ZMQ Requester: " requester]
 r: zmq/connect requester "tcp://127.0.0.1:5556"
 ZMQ_ASSERT(r)
 
-buffer: allocate 10
+buffer: allocate 256
 
 n: 0
+bytes: 0
+
 while [n < 10][
 	n: n + 1
 	print-line ["Sending Hello " n]
-	r: zmq/send requester as byte-ptr! "Hello" 5 0
-	ZMQ_ASSERT(r) if r < 0 [break]
-
-    r: zmq/recv requester buffer 10 0
-    ZMQ_ASSERT(r) if r < 0 [break]
+	bytes: zmq/send requester as byte-ptr! "Hello" 5 0
+	if bytes < 0 [
+		ZMQ_ASSERT(bytes)
+		break
+	]
+    bytes: zmq/recv requester buffer 255 0
+    either bytes < 0 [
+    	ZMQ_ASSERT(bytes)
+    	break
+    ][
+		if bytes > 255 [bytes: 255]
+		bytes: bytes + 1
+		buffer/bytes: #"^@" ;to create valid c-string ending just in case
+	]
     print-line ["Received " n ": " as c-string! buffer]
 ]
 
 zmq/close requester
 zmq/ctx_destroy ctx
+free buffer

--- a/Library/ZeroMQ/ZeroMQ-Hello-server.reds
+++ b/Library/ZeroMQ/ZeroMQ-Hello-server.reds
@@ -11,7 +11,7 @@ Red/System [
 	Comment: {
 		This script needs external library, which can be downloaded from this site:
 		http://zeromq.org/area:download
-		(tested with xz-5.2.3-windows\[bin_i686|bin_i686-sse2]\liblzma.dll)
+		(tested with libzmq-v120-mt-4_0_4.dll - renamed to libzmq.dll - on Win10)
 	}
 ]
 

--- a/Library/ZeroMQ/ZeroMQ-Hello-server.reds
+++ b/Library/ZeroMQ/ZeroMQ-Hello-server.reds
@@ -40,11 +40,17 @@ if r <> 0 [
 	quit -1
 ]
 
-buffer: allocate 10
+buffer: allocate 256
+bytes: 0
 forever [
 	print-line "Waiting for request..."
-	r: zmq/recv responder buffer 10 0
-	ZMQ_ASSERT(r)
+	bytes: zmq/recv responder buffer 255 0
+	ZMQ_ASSERT(bytes)
+	if bytes >= 0 [
+		if bytes > 255 [bytes: 255]
+		bytes: bytes + 1
+		buffer/bytes: #"^@" ;to create valid c-string ending just in case
+	]
 	print-line ["Received request: " as c-string! buffer]
 	r: zmq/send responder as byte-ptr! "World" 5 0
 	ZMQ_ASSERT(r)

--- a/Library/ZeroMQ/ZeroMQ.reds
+++ b/Library/ZeroMQ/ZeroMQ.reds
@@ -11,7 +11,7 @@ Red/System [
 	Comment: {
 		This script needs external library, which can be downloaded from this site:
 		http://zeromq.org/area:download
-		(tested with xz-5.2.3-windows\[bin_i686|bin_i686-sse2]\liblzma.dll)
+		(tested with libzmq-v120-mt-4_0_4.dll - renamed to libzmq.dll - on Win10)
 	}
 ]
 

--- a/Library/ZeroMQ/ZeroMQ.reds
+++ b/Library/ZeroMQ/ZeroMQ.reds
@@ -356,5 +356,25 @@ ZMQ: context [
 			timeout [integer!]
 			return: [integer!]
 		]
+		;*  Built-in message proxy (3-way)
+		proxy: "zmq_proxy" [
+			frontend [zmq-socket!]
+			backend  [zmq-socket!]
+			capture  [zmq-socket!]
+			return: [integer!]
+		]
+		;*  Encode a binary key as printable text using ZMQ RFC 32
+		z85_encode: "zmq_z85_encode" [
+			dest   [c-string!]
+			data   [byte-ptr!]
+			size   [integer!]
+			return: [c-string!]
+		]
+		;*  Encode a binary key from printable text per ZMQ RFC 32
+		z85_decode: "zmq_z85_decode" [
+			dest    [byte-ptr!]
+			string  [c-string!]
+			return: [byte-ptr!]
+		]
 	]]
 ]


### PR DESCRIPTION
Better to use this in the example too as it demonstrates, how to get received content of the buffer as a valid c-string! (ZMQ does not add null by default so previous version is not safe.