### PR TITLE
Renaming definitions using -ref! to use -ptr! so it is consistent with Red runtime

### DIFF
--- a/Library/Portaudio/examples/pa-record.reds
+++ b/Library/Portaudio/examples/pa-record.reds
@@ -177,7 +177,7 @@ recordSound: func[
     inputParameters/suggestedLatency: deviceInfo/defaultLowInputLatency
     inputParameters/hostApiSpecificStreamInfo: null
     
-    stream-ref: declare PaStream-ref!
+    stream-ref: declare PaStream-ptr!
 
     print-line ["Device: " inputParameters/device]
 

--- a/Library/Portaudio/examples/pa-saw-synth.reds
+++ b/Library/Portaudio/examples/pa-saw-synth.reds
@@ -82,7 +82,7 @@ playSound: func[
     userData/pitch-left:  as float32! 0.01
     userData/pitch-right: as float32! 0.03
     
-    stream-ref: declare PaStream-ref!
+    stream-ref: declare PaStream-ptr!
 
     err: Pa_OpenDefaultStream
               stream-ref

--- a/Library/Portaudio/examples/pa-saw.reds
+++ b/Library/Portaudio/examples/pa-saw.reds
@@ -80,7 +80,7 @@ playSound: func[
     userData/pitch-left:  as float32! 0.01
     userData/pitch-right: as float32! 0.03
     
-    stream-ref: declare PaStream-ref!
+    stream-ref: declare PaStream-ptr!
 
     err: Pa_OpenDefaultStream
               stream-ref

--- a/Library/Portaudio/examples/pa-sine.reds
+++ b/Library/Portaudio/examples/pa-sine.reds
@@ -123,7 +123,7 @@ playSound: func[
     outputParameters/sampleFormat:     paFloat32 ;32 bit floating point output
     outputParameters/suggestedLatency: 0.050 ;Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
     outputParameters/hostApiSpecificStreamInfo: null
-    stream-ref: declare PaStream-ref!
+    stream-ref: declare PaStream-ptr!
 
     err: Pa_OpenStream
               stream-ref

--- a/Library/Portaudio/examples/pa-write-sine.reds
+++ b/Library/Portaudio/examples/pa-write-sine.reds
@@ -84,7 +84,7 @@ playSound: func[
     outputParameters/sampleFormat:     paFloat32 ;32 bit floating point output
     outputParameters/suggestedLatency: 0.050 ;Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
     outputParameters/hostApiSpecificStreamInfo: null
-    stream-ref: declare PaStream-ref!
+    stream-ref: declare PaStream-ptr!
 
     err: Pa_OpenStream
               stream-ref

--- a/Library/Portaudio/portaudio.reds
+++ b/Library/Portaudio/portaudio.reds
@@ -14,21 +14,7 @@ Red/System [
 	#default  [   ]
 ]
 
-long-long-ptr!: alias struct! [lo [integer!] hi [integer!]] ;@@ There is no `int64!` datatype in Red/System yet
-#define long-long!        float! ;@@ struct is passed by reference so far so I must fake passing `long long` using `float!`
-#define MAX_32_PRECISION 4294967296.0
-int64-to-float: func[i [long-long-ptr!]	return: [float!]][
-	(MAX_32_PRECISION * as float! i/hi)  + (as float! i/lo) ;@@ float can be used as a workaround to pass long-long! value in function call (instead int64!)
-]
-float-to-int64: func[f [float!] return: [long-long-ptr!] /local i [long-long-ptr!] ][
-	i: declare long-long-ptr!
-	i/hi: as integer! (f / MAX_32_PRECISION)
-	i/lo: as integer! f
-	i
-]
-ZERO_INT64: declare long-long-ptr! [0 0]
-
-
+#include %../os/definitions.reds ;common aliases and defines
 
 #define PaHostApiIndex! integer!
 #define PaDeviceIndex!  integer!
@@ -36,7 +22,7 @@ ZERO_INT64: declare long-long-ptr! [0 0]
 #define PaError!        integer!
 
 #define PaStream!     [pointer! [integer!]]
-PaStream-ref!:  alias struct! [value [PaStream!]]
+PaStream-ptr!:  alias struct! [value [PaStream!]]
 
 PaVersionInfo!: alias struct! [
 	versionMajor    [integer!]
@@ -625,7 +611,7 @@ PaStreamCallbackTimeInfo!: alias struct! [
 
 		Pa_OpenStream: "Pa_OpenStream" [
 			; Opens a stream for either input, output or both.
-			stream [PaStream-ref!]
+			stream [PaStream-ptr!]
 			; @param stream The address of a PaStream pointer which will receive
 			; a pointer to the newly opened stream.
             inputParameters  [PaStreamParameters!]
@@ -677,7 +663,7 @@ PaStreamCallbackTimeInfo!: alias struct! [
         Pa_OpenDefaultStream: "Pa_OpenDefaultStream" [
 			; A simplified version of Pa_OpenStream() that opens the default input
 			; and/or output devices.
-			stream [PaStream-ref!]
+			stream [PaStream-ptr!]
 			; @param stream The address of a PaStream pointer which will receive
 			; a pointer to the newly opened stream.
             numInputChannels  [integer!]

--- a/Library/SQLite/SQLite3-test-basic.reds
+++ b/Library/SQLite/SQLite3-test-basic.reds
@@ -10,8 +10,8 @@ Red/System [
 #include %SQLite3.reds
 
 db:     declare sqlite3!
-db-ref: declare sqlite3-ref!
-errmsg: declare string-ref!
+db-ptr: declare sqlite3-ptr!
+errmsg: declare string-ptr!
 data:   declare int-ptr!
 str:    declare c-string!
 
@@ -36,8 +36,8 @@ on-row: function [[cdecl]
 	"Process a result row."
 	data		[int-ptr!]
 	columns		[integer!]
-	values		[string-ref!]
-	names		[string-ref!]
+	values		[string-ptr!]
+	names		[string-ptr!]
 	return:		[integer!]
 ][
 	data/value: data/value + 1
@@ -74,9 +74,9 @@ status: sqlite3_initialize
 either SQLITE_OK <> status [
 	print-line ["SQLite init failed with status: " status]
 ][
-	status: sqlite3_open "test.db" db-ref
+	status: sqlite3_open "test.db" db-ptr
 	if SQLITE_OK = status [
-		db: db-ref/value
+		db: db-ptr/value
 		print-line ["DB: " db]
 
 		sqlite3_trace  db :on-trace null

--- a/Library/SQLite/SQLite3-test.reds
+++ b/Library/SQLite/SQLite3-test.reds
@@ -9,8 +9,8 @@ Red/System [
 #include %SQLite3.reds
 
 db:     declare sqlite3!
-db-ref: declare sqlite3-ref!
-errmsg: declare string-ref!
+db-ptr: declare sqlite3-ptr!
+errmsg: declare string-ptr!
 data:   declare int-ptr!
 str:    declare c-string!
 
@@ -37,8 +37,8 @@ on-row: function [[cdecl]
 	"Process a result row."
 	data		[int-ptr!]
 	columns		[integer!]
-	values		[string-ref!]
-	names		[string-ref!]
+	values		[string-ptr!]
+	names		[string-ptr!]
 	return:		[integer!]
 ][
 	data/value: data/value + 1
@@ -116,9 +116,9 @@ either SQLITE_OK <> status [
 		n: n + 1
 	]
 
-	status: sqlite3_open "test.db" db-ref
+	status: sqlite3_open "test.db" db-ptr
 	if SQLITE_OK = status [
-		db: db-ref/value
+		db: db-ptr/value
 		print-line ["DB: " db]
 
 		sqlite3_trace_v2  db (SQLITE_TRACE_STMT or SQLITE_TRACE_PROFILE) :on-trace null

--- a/Library/SQLite/SQLite3.red
+++ b/Library/SQLite/SQLite3.red
@@ -17,8 +17,8 @@ Red [
 
 	sqlite: context [
 		db-current: declare sqlite3!
-		db-ref: declare sqlite3-ref!
-		errmsg: declare string-ref!
+		db-ref: declare sqlite3-ptr!
+		errmsg: declare string-ptr!
 		data:   declare int-ptr!
 		str:    declare c-string!
 
@@ -103,8 +103,8 @@ Red [
 			"Process a result row."
 			data		[int-ptr!]
 			columns		[integer!]
-			values		[string-ref!]
-			names		[string-ref!]
+			values		[string-ptr!]
+			names		[string-ptr!]
 			return:		[integer!]
 		][
 			
@@ -127,8 +127,8 @@ Red [
 			"Process a result row."
 			data		[int-ptr!]
 			columns		[integer!]
-			values		[string-ref!]
-			names		[string-ref!]
+			values		[string-ptr!]
+			names		[string-ptr!]
 			return:		[integer!]
 			/local
 				blk     [red-block!]

--- a/Library/SQLite/SQLite3.reds
+++ b/Library/SQLite/SQLite3.reds
@@ -32,14 +32,14 @@ Red/System [
 #define sqlite3-vfs!                [pointer! [integer!]]
 #define sqlite3-changegroup!        [pointer! [integer!]]
 
-sqlite3-ref!:                alias struct! [value [sqlite3!]]
-sqlite3-blob-ref!:           alias struct! [value [sqlite3-blob!]]
-sqlite3-changeset-iter-ref!: alias struct! [value [sqlite3-changeset-iter!]]
-sqlite3-session-ref!:        alias struct! [value [sqlite3-session!]]
-sqlite3-snapshot-ref!:       alias struct! [value [sqlite3-snapshot!]]
-sqlite3-stmt-ref!:           alias struct! [value [sqlite3-stmt!]]
-sqlite3-value-ref!:          alias struct! [value [sqlite3-value!]]
-sqlite3-changegroup-ref!:    alias struct! [value [sqlite3-changegroup!]]
+sqlite3-ptr!:                alias struct! [value [sqlite3!]]
+sqlite3-blob-ptr!:           alias struct! [value [sqlite3-blob!]]
+sqlite3-changeset-iter-ptr!: alias struct! [value [sqlite3-changeset-iter!]]
+sqlite3-session-ptr!:        alias struct! [value [sqlite3-session!]]
+sqlite3-snapshot-ptr!:       alias struct! [value [sqlite3-snapshot!]]
+sqlite3-stmt-ptr!:           alias struct! [value [sqlite3-stmt!]]
+sqlite3-value-ptr!:          alias struct! [value [sqlite3-value!]]
+sqlite3-changegroup-ptr!:    alias struct! [value [sqlite3-changegroup!]]
 
 
 ;- Binding based on version:
@@ -2228,12 +2228,12 @@ sqlite3_exec: "sqlite3_exec" [
 	callback [function! [
 		arg1    [int-ptr!] 
 		arg2    [integer!] 
-		arg3    [string-ref!] 
-		arg4    [string-ref!] 
+		arg3    [string-ptr!] 
+		arg4    [string-ptr!] 
 		return: [integer!]
 	]]
 	arg4     [int-ptr!]                ; 1st argument to callback 
-	errmsg   [string-ref!]             ; Error msg written here 
+	errmsg   [string-ptr!]             ; Error msg written here 
 	return: [integer!]
 ]
 
@@ -2457,7 +2457,7 @@ sqlite3_extended_result_codes: "sqlite3_extended_result_codes" [
 
 sqlite3_last_insert_rowid: "sqlite3_last_insert_rowid" [
 	arg1    [sqlite3!]                 ;sqlite3*
-	return: [int64! value]
+	return: [int64-value!]
 ]
 
 ;- Set the Last Insert Rowid value.
@@ -2470,7 +2470,7 @@ sqlite3_last_insert_rowid: "sqlite3_last_insert_rowid" [
 
 sqlite3_set_last_insert_rowid: "sqlite3_set_last_insert_rowid" [
 	arg1    [sqlite3!]                 ;sqlite3*
-	arg2    [int64! value]             ;sqlite3_int64
+	arg2    [int64-value!]             ;sqlite3_int64
 ]
 
 ;- Count The Number Of Rows Modified
@@ -2633,7 +2633,7 @@ sqlite3_complete: "sqlite3_complete" [
 	return: [integer!]
 ]
 sqlite3_complete16: "sqlite3_complete16" [
-	sql     [byte-ptr!]                ;const void *
+	sql     [int-ptr!]                 ;const void *
 	return: [integer!]
 ]
 
@@ -2810,14 +2810,14 @@ sqlite3_busy_timeout: "sqlite3_busy_timeout" [
 sqlite3_get_table: "sqlite3_get_table" [
 	db        [sqlite3!]               ; An open database 
 	zSql      [c-string!]              ; SQL to be evaluated 
-	pazResult [string-ref-ref!]        ; Results of the query 
+	pazResult [string-ptr-ptr!]        ; Results of the query 
 	pnRow     [int-ptr!]               ; Number of result rows written here 
 	pnColumn  [int-ptr!]               ; Number of result columns written here 
-	pzErrmsg  [string-ref!]            ; Error msg written here 
+	pzErrmsg  [string-ptr!]            ; Error msg written here 
 	return: [integer!]
 ]
 sqlite3_free_table: "sqlite3_free_table" [
-	result  [string-ref!]              ;char **
+	result  [string-ptr!]              ;char **
 ]
 
 ;- Formatted String Printing Functions
@@ -3024,7 +3024,7 @@ sqlite3_malloc: "sqlite3_malloc" [
 	return: [int-ptr!]
 ]
 sqlite3_malloc64: "sqlite3_malloc64" [
-	arg1    [uint64! value]            ;sqlite3_uint64
+	arg1    [uint64-value!]            ;sqlite3_uint64
 	return: [int-ptr!]
 ]
 sqlite3_realloc: "sqlite3_realloc" [
@@ -3034,7 +3034,7 @@ sqlite3_realloc: "sqlite3_realloc" [
 ]
 sqlite3_realloc64: "sqlite3_realloc64" [
 	arg1    [int-ptr!]                 ;void*
-	arg2    [uint64! value]            ;sqlite3_uint64
+	arg2    [uint64-value!]            ;sqlite3_uint64
 	return: [int-ptr!]
 ]
 sqlite3_free: "sqlite3_free" [
@@ -3042,7 +3042,7 @@ sqlite3_free: "sqlite3_free" [
 ]
 sqlite3_msize: "sqlite3_msize" [
 	arg1    [int-ptr!]                 ;void*
-	return: [uint64! value]
+	return: [uint64-value!]
 ]
 
 ;- Memory Allocator Statistics
@@ -3069,11 +3069,11 @@ sqlite3_msize: "sqlite3_msize" [
 
 
 sqlite3_memory_used: "sqlite3_memory_used" [
-	return: [int64! value]
+	return: [int64-value!]
 ]
 sqlite3_memory_highwater: "sqlite3_memory_highwater" [
 	resetFlag [integer!]               ;int
-	return: [int64! value]
+	return: [int64-value!]
 ]
 
 ;- Pseudo-Random Number Generator
@@ -3252,7 +3252,7 @@ sqlite3_profile: "sqlite3_profile" [
 	xProfile [function! [
 		arg1    [int-ptr!] 
 		arg2    [c-string!] 
-		arg3    [uint64! value] 
+		arg3    [uint64-value!] 
 	]]
 	arg3     [int-ptr!]                ;void*
 	return: [int-ptr!]
@@ -3572,17 +3572,17 @@ sqlite3_progress_handler: "sqlite3_progress_handler" [
 
 sqlite3_open: "sqlite3_open" [
 	filename [c-string!]               ; Database filename (UTF-8) 
-	ppDb     [sqlite3-ref!]            ; OUT: SQLite db handle 
+	ppDb     [sqlite3-ptr!]            ; OUT: SQLite db handle 
 	return: [integer!]
 ]
 sqlite3_open16: "sqlite3_open16" [
-	filename [byte-ptr!]               ; Database filename (UTF-16) 
-	ppDb     [sqlite3-ref!]            ; OUT: SQLite db handle 
+	filename [int-ptr!]                ; Database filename (UTF-16) 
+	ppDb     [sqlite3-ptr!]            ; OUT: SQLite db handle 
 	return: [integer!]
 ]
 sqlite3_open_v2: "sqlite3_open_v2" [
 	filename [c-string!]               ; Database filename (UTF-8) 
-	ppDb     [sqlite3-ref!]            ; OUT: SQLite db handle 
+	ppDb     [sqlite3-ptr!]            ; OUT: SQLite db handle 
 	flags    [integer!]                ; Flags 
 	zVfs     [c-string!]               ; Name of VFS module to use 
 	return: [integer!]
@@ -3641,8 +3641,8 @@ sqlite3_uri_boolean: "sqlite3_uri_boolean" [
 sqlite3_uri_int64: "sqlite3_uri_int64" [
 	arg1    [c-string!]                ;const char*
 	arg2    [c-string!]                ;const char*
-	arg3    [int64! value]             ;sqlite3_int64
-	return: [int64! value]
+	arg3    [int64-value!]             ;sqlite3_int64
+	return: [int64-value!]
 ]
 
 ;- Error Codes And Messages
@@ -3700,7 +3700,7 @@ sqlite3_errmsg: "sqlite3_errmsg" [
 ]
 sqlite3_errmsg16: "sqlite3_errmsg16" [
 	arg1    [sqlite3!]                 ;sqlite3*
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_errstr: "sqlite3_errstr" [
 	arg1    [integer!]                 ;int
@@ -3858,16 +3858,16 @@ sqlite3_prepare: "sqlite3_prepare" [
 	db      [sqlite3!]                 ; Database handle 
 	zSql    [c-string!]                ; SQL statement, UTF-8 encoded 
 	nByte   [integer!]                 ; Maximum length of zSql in bytes. 
-	ppStmt  [sqlite3-stmt-ref!]        ; OUT: Statement handle 
-	pzTail  [string-ref!]              ; OUT: Pointer to unused portion of zSql 
+	ppStmt  [sqlite3-stmt-ptr!]        ; OUT: Statement handle 
+	pzTail  [string-ptr!]              ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 sqlite3_prepare_v2: "sqlite3_prepare_v2" [
 	db      [sqlite3!]                 ; Database handle 
 	zSql    [c-string!]                ; SQL statement, UTF-8 encoded 
 	nByte   [integer!]                 ; Maximum length of zSql in bytes. 
-	ppStmt  [sqlite3-stmt-ref!]        ; OUT: Statement handle 
-	pzTail  [string-ref!]              ; OUT: Pointer to unused portion of zSql 
+	ppStmt  [sqlite3-stmt-ptr!]        ; OUT: Statement handle 
+	pzTail  [string-ptr!]              ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 sqlite3_prepare_v3: "sqlite3_prepare_v3" [
@@ -3875,33 +3875,33 @@ sqlite3_prepare_v3: "sqlite3_prepare_v3" [
 	zSql      [c-string!]              ; SQL statement, UTF-8 encoded 
 	nByte     [integer!]               ; Maximum length of zSql in bytes. 
 	prepFlags [integer!]               ; Zero or more SQLITE_PREPARE_ flags 
-	ppStmt    [sqlite3-stmt-ref!]      ; OUT: Statement handle 
-	pzTail    [string-ref!]            ; OUT: Pointer to unused portion of zSql 
+	ppStmt    [sqlite3-stmt-ptr!]      ; OUT: Statement handle 
+	pzTail    [string-ptr!]            ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 sqlite3_prepare16: "sqlite3_prepare16" [
 	db      [sqlite3!]                 ; Database handle 
-	zSql    [byte-ptr!]                ; SQL statement, UTF-16 encoded 
+	zSql    [int-ptr!]                 ; SQL statement, UTF-16 encoded 
 	nByte   [integer!]                 ; Maximum length of zSql in bytes. 
-	ppStmt  [sqlite3-stmt-ref!]        ; OUT: Statement handle 
-	pzTail  [binary-ref!]              ; OUT: Pointer to unused portion of zSql 
+	ppStmt  [sqlite3-stmt-ptr!]        ; OUT: Statement handle 
+	pzTail  [int-ptr!]                 ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 sqlite3_prepare16_v2: "sqlite3_prepare16_v2" [
 	db      [sqlite3!]                 ; Database handle 
-	zSql    [byte-ptr!]                ; SQL statement, UTF-16 encoded 
+	zSql    [int-ptr!]                 ; SQL statement, UTF-16 encoded 
 	nByte   [integer!]                 ; Maximum length of zSql in bytes. 
-	ppStmt  [sqlite3-stmt-ref!]        ; OUT: Statement handle 
-	pzTail  [binary-ref!]              ; OUT: Pointer to unused portion of zSql 
+	ppStmt  [sqlite3-stmt-ptr!]        ; OUT: Statement handle 
+	pzTail  [int-ptr!]                 ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 sqlite3_prepare16_v3: "sqlite3_prepare16_v3" [
 	db        [sqlite3!]               ; Database handle 
-	zSql      [byte-ptr!]              ; SQL statement, UTF-16 encoded 
+	zSql      [int-ptr!]               ; SQL statement, UTF-16 encoded 
 	nByte     [integer!]               ; Maximum length of zSql in bytes. 
 	prepFlags [integer!]               ; Zero or more SQLITE_PREPARE_ flags 
-	ppStmt    [sqlite3-stmt-ref!]      ; OUT: Statement handle 
-	pzTail    [binary-ref!]            ; OUT: Pointer to unused portion of zSql 
+	ppStmt    [sqlite3-stmt-ptr!]      ; OUT: Statement handle 
+	pzTail    [int-ptr!]               ; OUT: Pointer to unused portion of zSql 
 	return: [integer!]
 ]
 
@@ -4128,15 +4128,15 @@ sqlite3_stmt_busy: "sqlite3_stmt_busy" [
 sqlite3_bind_blob: "sqlite3_bind_blob" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	arg3    [byte-ptr!]                ;const void*
+	arg3    [int-ptr!]                 ;const void*
 	n       [integer!]                 ;int
 	return: [integer!]
 ]
 sqlite3_bind_blob64: "sqlite3_bind_blob64" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	arg3    [byte-ptr!]                ;const void*
-	arg4    [uint64! value]            ;sqlite3_uint64
+	arg3    [int-ptr!]                 ;const void*
+	arg4    [uint64-value!]            ;sqlite3_uint64
 	return: [integer!]
 ]
 sqlite3_bind_double: "sqlite3_bind_double" [
@@ -4154,7 +4154,7 @@ sqlite3_bind_int: "sqlite3_bind_int" [
 sqlite3_bind_int64: "sqlite3_bind_int64" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	arg3    [int64! value]             ;sqlite3_int64
+	arg3    [int64-value!]             ;sqlite3_int64
 	return: [integer!]
 ]
 sqlite3_bind_null: "sqlite3_bind_null" [
@@ -4172,7 +4172,7 @@ sqlite3_bind_text: "sqlite3_bind_text" [
 sqlite3_bind_text16: "sqlite3_bind_text16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	arg3    [byte-ptr!]                ;const void*
+	arg3    [int-ptr!]                 ;const void*
 	arg4    [integer!]                 ;int
 	return: [integer!]
 ]
@@ -4180,7 +4180,7 @@ sqlite3_bind_text64: "sqlite3_bind_text64" [
 	arg1     [sqlite3-stmt!]           ;sqlite3_stmt*
 	arg2     [integer!]                ;int
 	arg3     [c-string!]               ;const char*
-	arg4     [uint64! value]           ;sqlite3_uint64
+	arg4     [uint64-value!]           ;sqlite3_uint64
 	arg5     [function! [
 		arg1    [int-ptr!] 
 	]]
@@ -4209,7 +4209,7 @@ sqlite3_bind_zeroblob: "sqlite3_bind_zeroblob" [
 sqlite3_bind_zeroblob64: "sqlite3_bind_zeroblob64" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	arg3    [uint64! value]            ;sqlite3_uint64
+	arg3    [uint64-value!]            ;sqlite3_uint64
 	return: [integer!]
 ]
 
@@ -4358,7 +4358,7 @@ sqlite3_column_name: "sqlite3_column_name" [
 sqlite3_column_name16: "sqlite3_column_name16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	N       [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 
 ;- Source Of Data In A Query Result
@@ -4415,7 +4415,7 @@ sqlite3_column_database_name: "sqlite3_column_database_name" [
 sqlite3_column_database_name16: "sqlite3_column_database_name16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_column_table_name: "sqlite3_column_table_name" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
@@ -4425,7 +4425,7 @@ sqlite3_column_table_name: "sqlite3_column_table_name" [
 sqlite3_column_table_name16: "sqlite3_column_table_name16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_column_origin_name: "sqlite3_column_origin_name" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
@@ -4435,7 +4435,7 @@ sqlite3_column_origin_name: "sqlite3_column_origin_name" [
 sqlite3_column_origin_name16: "sqlite3_column_origin_name16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 
 ;- Declared Datatype Of A Query Result
@@ -4476,7 +4476,7 @@ sqlite3_column_decltype: "sqlite3_column_decltype" [
 sqlite3_column_decltype16: "sqlite3_column_decltype16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	arg2    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 
 ;- Evaluate An SQL Statement
@@ -4788,7 +4788,7 @@ sqlite3_data_count: "sqlite3_data_count" [
 sqlite3_column_blob: "sqlite3_column_blob" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	iCol    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_column_double: "sqlite3_column_double" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
@@ -4803,7 +4803,7 @@ sqlite3_column_int: "sqlite3_column_int" [
 sqlite3_column_int64: "sqlite3_column_int64" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	iCol    [integer!]                 ;int
-	return: [int64! value]
+	return: [int64-value!]
 ]
 sqlite3_column_text: "sqlite3_column_text" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
@@ -4813,7 +4813,7 @@ sqlite3_column_text: "sqlite3_column_text" [
 sqlite3_column_text16: "sqlite3_column_text16" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
 	iCol    [integer!]                 ;int
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_column_value: "sqlite3_column_value" [
 	arg1    [sqlite3-stmt!]            ;sqlite3_stmt*
@@ -5004,12 +5004,12 @@ sqlite3_create_function: "sqlite3_create_function" [
 	xFunc         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xStep         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xFinal        [function! [
 		arg1         [sqlite3-context!] 
@@ -5018,19 +5018,19 @@ sqlite3_create_function: "sqlite3_create_function" [
 ]
 sqlite3_create_function16: "sqlite3_create_function16" [
 	db            [sqlite3!]           ;sqlite3 *
-	zFunctionName [byte-ptr!]          ;const void *
+	zFunctionName [int-ptr!]           ;const void *
 	nArg          [integer!]           ;int
 	eTextRep      [integer!]           ;int
 	pApp          [int-ptr!]           ;void *
 	xFunc         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xStep         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xFinal        [function! [
 		arg1         [sqlite3-context!] 
@@ -5046,12 +5046,12 @@ sqlite3_create_function_v2: "sqlite3_create_function_v2" [
 	xFunc         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xStep         [function! [
 		arg1         [sqlite3-context!] 
 		arg2         [integer!] 
-		arg3         [sqlite3-value-ref!] 
+		arg3         [sqlite3-value-ptr!] 
 	]]
 	xFinal        [function! [
 		arg1         [sqlite3-context!] 
@@ -5093,11 +5093,11 @@ sqlite3_thread_cleanup: "sqlite3_thread_cleanup" [
 sqlite3_memory_alarm: "sqlite3_memory_alarm" [
 	arg1    [function! [
 		arg1   [int-ptr!] 
-		arg2   [int64! value] 
+		arg2   [int64-value!] 
 		arg3   [integer!] 
 	]]
 	arg2    [int-ptr!]                 ;void*
-	arg3    [int64! value]             ;sqlite3_int64
+	arg3    [int64-value!]             ;sqlite3_int64
 	return: [integer!]
 ]
 
@@ -5186,7 +5186,7 @@ sqlite3_memory_alarm: "sqlite3_memory_alarm" [
 
 sqlite3_value_blob: "sqlite3_value_blob" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_value_double: "sqlite3_value_double" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
@@ -5198,7 +5198,7 @@ sqlite3_value_int: "sqlite3_value_int" [
 ]
 sqlite3_value_int64: "sqlite3_value_int64" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
-	return: [int64! value]
+	return: [int64-value!]
 ]
 sqlite3_value_pointer: "sqlite3_value_pointer" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
@@ -5211,15 +5211,15 @@ sqlite3_value_text: "sqlite3_value_text" [
 ]
 sqlite3_value_text16: "sqlite3_value_text16" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_value_text16le: "sqlite3_value_text16le" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_value_text16be: "sqlite3_value_text16be" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
-	return: [byte-ptr!]
+	return: [int-ptr!]
 ]
 sqlite3_value_bytes: "sqlite3_value_bytes" [
 	arg1    [sqlite3-value!]           ;sqlite3_value*
@@ -5553,13 +5553,13 @@ sqlite3_set_auxdata: "sqlite3_set_auxdata" [
 
 sqlite3_result_blob: "sqlite3_result_blob" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
+	arg2    [int-ptr!]                 ;const void*
 	arg3    [integer!]                 ;int
 ]
 sqlite3_result_blob64: "sqlite3_result_blob64" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
-	arg3    [uint64! value]            ;sqlite3_uint64
+	arg2    [int-ptr!]                 ;const void*
+	arg3    [uint64-value!]            ;sqlite3_uint64
 ]
 sqlite3_result_double: "sqlite3_result_double" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
@@ -5572,7 +5572,7 @@ sqlite3_result_error: "sqlite3_result_error" [
 ]
 sqlite3_result_error16: "sqlite3_result_error16" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
+	arg2    [int-ptr!]                 ;const void*
 	arg3    [integer!]                 ;int
 ]
 sqlite3_result_error_toobig: "sqlite3_result_error_toobig" [
@@ -5591,7 +5591,7 @@ sqlite3_result_int: "sqlite3_result_int" [
 ]
 sqlite3_result_int64: "sqlite3_result_int64" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [int64! value]             ;sqlite3_int64
+	arg2    [int64-value!]             ;sqlite3_int64
 ]
 sqlite3_result_null: "sqlite3_result_null" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
@@ -5604,7 +5604,7 @@ sqlite3_result_text: "sqlite3_result_text" [
 sqlite3_result_text64: "sqlite3_result_text64" [
 	arg1     [sqlite3-context!]        ;sqlite3_context*
 	arg2     [c-string!]               ;const char*
-	arg3     [uint64! value]           ;sqlite3_uint64
+	arg3     [uint64-value!]           ;sqlite3_uint64
 	arg4     [function! [
 		arg1    [int-ptr!] 
 	]]
@@ -5612,17 +5612,17 @@ sqlite3_result_text64: "sqlite3_result_text64" [
 ]
 sqlite3_result_text16: "sqlite3_result_text16" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
+	arg2    [int-ptr!]                 ;const void*
 	arg3    [integer!]                 ;int
 ]
 sqlite3_result_text16le: "sqlite3_result_text16le" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
+	arg2    [int-ptr!]                 ;const void*
 	arg3    [integer!]                 ;int
 ]
 sqlite3_result_text16be: "sqlite3_result_text16be" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	arg2    [byte-ptr!]                ;const void*
+	arg2    [int-ptr!]                 ;const void*
 	arg3    [integer!]                 ;int
 ]
 sqlite3_result_value: "sqlite3_result_value" [
@@ -5640,7 +5640,7 @@ sqlite3_result_zeroblob: "sqlite3_result_zeroblob" [
 ]
 sqlite3_result_zeroblob64: "sqlite3_result_zeroblob64" [
 	arg1    [sqlite3-context!]         ;sqlite3_context*
-	n       [uint64! value]            ;sqlite3_uint64
+	n       [uint64-value!]            ;sqlite3_uint64
 	return: [integer!]
 ]
 
@@ -5749,9 +5749,9 @@ sqlite3_create_collation: "sqlite3_create_collation" [
 	xCompare [function! [
 		arg1    [int-ptr!] 
 		arg2    [integer!] 
-		arg3    [byte-ptr!] 
+		arg3    [int-ptr!] 
 		arg4    [integer!] 
-		arg5    [byte-ptr!] 
+		arg5    [int-ptr!] 
 		return: [integer!]
 	]]
 	return: [integer!]
@@ -5764,9 +5764,9 @@ sqlite3_create_collation_v2: "sqlite3_create_collation_v2" [
 	xCompare [function! [
 		arg1    [int-ptr!] 
 		arg2    [integer!] 
-		arg3    [byte-ptr!] 
+		arg3    [int-ptr!] 
 		arg4    [integer!] 
-		arg5    [byte-ptr!] 
+		arg5    [int-ptr!] 
 		return: [integer!]
 	]]
 	xDestroy [function! [
@@ -5776,15 +5776,15 @@ sqlite3_create_collation_v2: "sqlite3_create_collation_v2" [
 ]
 sqlite3_create_collation16: "sqlite3_create_collation16" [
 	arg1     [sqlite3!]                ;sqlite3*
-	zName    [byte-ptr!]               ;const void *
+	zName    [int-ptr!]                ;const void *
 	eTextRep [integer!]                ;int
 	pArg     [int-ptr!]                ;void *
 	xCompare [function! [
 		arg1    [int-ptr!] 
 		arg2    [integer!] 
-		arg3    [byte-ptr!] 
+		arg3    [int-ptr!] 
 		arg4    [integer!] 
-		arg5    [byte-ptr!] 
+		arg5    [int-ptr!] 
 		return: [integer!]
 	]]
 	return: [integer!]
@@ -5835,33 +5835,33 @@ sqlite3_collation_needed16: "sqlite3_collation_needed16" [
 		arg1   [int-ptr!] 
 		arg2   [sqlite3!] 
 		eTextRep [integer!] 
-		arg4   [byte-ptr!] 
+		arg4   [int-ptr!] 
 	]]
 	return: [integer!]
 ]
 sqlite3_key: "sqlite3_key" [
 	db      [sqlite3!]                 ; Database to be rekeyed 
-	pKey    [byte-ptr!]                ;const void *
+	pKey    [int-ptr!]                 ;const void *
 	nKey    [integer!]                 ; The key 
 	return: [integer!]
 ]
 sqlite3_key_v2: "sqlite3_key_v2" [
 	db      [sqlite3!]                 ; Database to be rekeyed 
 	zDbName [c-string!]                ; Name of the database 
-	pKey    [byte-ptr!]                ;const void *
+	pKey    [int-ptr!]                 ;const void *
 	nKey    [integer!]                 ; The key 
 	return: [integer!]
 ]
 sqlite3_rekey: "sqlite3_rekey" [
 	db      [sqlite3!]                 ; Database to be rekeyed 
-	pKey    [byte-ptr!]                ;const void *
+	pKey    [int-ptr!]                 ;const void *
 	nKey    [integer!]                 ; The new key 
 	return: [integer!]
 ]
 sqlite3_rekey_v2: "sqlite3_rekey_v2" [
 	db      [sqlite3!]                 ; Database to be rekeyed 
 	zDbName [c-string!]                ; Name of the database 
-	pKey    [byte-ptr!]                ;const void *
+	pKey    [int-ptr!]                 ;const void *
 	nKey    [integer!]                 ; The new key 
 	return: [integer!]
 ]
@@ -6113,7 +6113,7 @@ sqlite3_update_hook: "sqlite3_update_hook" [
 		arg2   [integer!] 
 		arg3   [c-string!] 
 		arg4   [c-string!] 
-		arg5   [int64! value] 
+		arg5   [int64-value!] 
 	]]
 	arg3    [int-ptr!]                 ;void*
 	return: [int-ptr!]
@@ -6247,8 +6247,8 @@ sqlite3_db_release_memory: "sqlite3_db_release_memory" [
 
 
 sqlite3_soft_heap_limit64: "sqlite3_soft_heap_limit64" [
-	N       [int64! value]             ;sqlite3_int64
-	return: [int64! value]
+	N       [int64-value!]             ;sqlite3_int64
+	return: [int64-value!]
 ]
 
 ;- Deprecated Soft Heap Limit Interface
@@ -6338,8 +6338,8 @@ sqlite3_table_column_metadata: "sqlite3_table_column_metadata" [
 	zDbName     [c-string!]            ; Database name or NULL 
 	zTableName  [c-string!]            ; Table name 
 	zColumnName [c-string!]            ; Column name 
-	pzDataType  [string-ref!]          ; OUTPUT: Declared data type 
-	pzCollSeq   [string-ref!]          ; OUTPUT: Collation sequence name 
+	pzDataType  [string-ptr!]          ; OUTPUT: Declared data type 
+	pzCollSeq   [string-ptr!]          ; OUTPUT: Collation sequence name 
 	pNotNull    [int-ptr!]             ; OUTPUT: True if NOT NULL constraint exists 
 	pPrimaryKey [int-ptr!]             ; OUTPUT: True if column part of PK 
 	pAutoinc    [int-ptr!]             ; OUTPUT: True if column is auto-increment 
@@ -6394,7 +6394,7 @@ sqlite3_load_extension: "sqlite3_load_extension" [
 	db       [sqlite3!]                ; Load the extension into this database connection 
 	zFile    [c-string!]               ; Name of the shared library containing extension 
 	zProc    [c-string!]               ; Entry point.  Derived from zFile if 0 
-	pzErrMsg [string-ref!]             ; Put error message here if not 0 
+	pzErrMsg [string-ptr!]             ; Put error message here if not 0 
 	return: [integer!]
 ]
 
@@ -6662,9 +6662,9 @@ sqlite3_blob_open: "sqlite3_blob_open" [
 	zDb     [c-string!]                ;const char *
 	zTable  [c-string!]                ;const char *
 	zColumn [c-string!]                ;const char *
-	iRow    [int64! value]             ;sqlite3_int64
+	iRow    [int64-value!]             ;sqlite3_int64
 	flags   [integer!]                 ;int
-	ppBlob  [sqlite3-blob-ref!]        ;sqlite3_blob **
+	ppBlob  [sqlite3-blob-ptr!]        ;sqlite3_blob **
 	return: [integer!]
 ]
 
@@ -6693,7 +6693,7 @@ sqlite3_blob_open: "sqlite3_blob_open" [
 
 sqlite3_blob_reopen: "sqlite3_blob_reopen" [
 	arg1    [sqlite3-blob!]            ;sqlite3_blob *
-	arg2    [int64! value]             ;sqlite3_int64
+	arg2    [int64-value!]             ;sqlite3_int64
 	return: [integer!]
 ]
 
@@ -6819,7 +6819,7 @@ sqlite3_blob_read: "sqlite3_blob_read" [
 
 sqlite3_blob_write: "sqlite3_blob_write" [
 	arg1    [sqlite3-blob!]            ;sqlite3_blob *
-	z       [byte-ptr!]                ;const void *
+	z       [int-ptr!]                 ;const void *
 	n       [integer!]                 ;int
 	iOffset [integer!]                 ;int
 	return: [integer!]
@@ -7150,8 +7150,8 @@ sqlite3_status: "sqlite3_status" [
 ]
 sqlite3_status64: "sqlite3_status64" [
 	op         [integer!]              ;int
-	pCurrent   [int64!]                ;sqlite3_int64 *
-	pHighwater [int64!]                ;sqlite3_int64 *
+	pCurrent   [int64-ptr!]            ;sqlite3_int64 *
+	pHighwater [int64-ptr!]            ;sqlite3_int64 *
 	resetFlag  [integer!]              ;int
 	return: [integer!]
 ]
@@ -8067,8 +8067,8 @@ sqlite3_preupdate_hook: "sqlite3_preupdate_hook" [
 		op        [integer!]  ; SQLITE_UPDATE, DELETE or INSERT 
 		zDb       [c-string!]  ; Database name 
 		zName     [c-string!]  ; Table name 
-		iKey1     [int64! value]  ; Rowid of row about to be deleted/updated 
-		iKey2     [int64! value]  ; New rowid value (for a rowid UPDATE) 
+		iKey1     [int64-value!]  ; Rowid of row about to be deleted/updated 
+		iKey2     [int64-value!]  ; New rowid value (for a rowid UPDATE) 
 	]]
 	arg3       [int-ptr!]              ;void*
 	return: [int-ptr!]
@@ -8076,7 +8076,7 @@ sqlite3_preupdate_hook: "sqlite3_preupdate_hook" [
 sqlite3_preupdate_old: "sqlite3_preupdate_old" [
 	arg1    [sqlite3!]                 ;sqlite3 *
 	arg2    [integer!]                 ;int
-	arg3    [sqlite3-value-ref!]       ;sqlite3_value **
+	arg3    [sqlite3-value-ptr!]       ;sqlite3_value **
 	return: [integer!]
 ]
 sqlite3_preupdate_count: "sqlite3_preupdate_count" [
@@ -8090,7 +8090,7 @@ sqlite3_preupdate_depth: "sqlite3_preupdate_depth" [
 sqlite3_preupdate_new: "sqlite3_preupdate_new" [
 	arg1    [sqlite3!]                 ;sqlite3 *
 	arg2    [integer!]                 ;int
-	arg3    [sqlite3-value-ref!]       ;sqlite3_value **
+	arg3    [sqlite3-value-ptr!]       ;sqlite3_value **
 	return: [integer!]
 ]
 
@@ -8155,7 +8155,7 @@ sqlite3_system_errno: "sqlite3_system_errno" [
 sqlite3_snapshot_get: "sqlite3_snapshot_get" [
 	db         [sqlite3!]              ;sqlite3 *
 	zSchema    [c-string!]             ;const char *
-	ppSnapshot [sqlite3-snapshot-ref!] ;sqlite3_snapshot **
+	ppSnapshot [sqlite3-snapshot-ptr!] ;sqlite3_snapshot **
 	return: [integer!]
 ]
 
@@ -8328,7 +8328,7 @@ sqlite3_rtree_query_callback: "sqlite3_rtree_query_callback" [
 sqlite3session_create: "sqlite3session_create" [
 	db        [sqlite3!]               ; Database handle 
 	zDb       [c-string!]              ; Name of db (e.g. "main") 
-	ppSession [sqlite3-session-ref!]   ; OUT: New session object 
+	ppSession [sqlite3-session-ptr!]   ; OUT: New session object 
 	return: [integer!]
 ]
 
@@ -8628,7 +8628,7 @@ sqlite3session_diff: "sqlite3session_diff" [
 	pSession [sqlite3-session!]        ;sqlite3_session *
 	zFromDb  [c-string!]               ;const char *
 	zTbl     [c-string!]               ;const char *
-	pzErrMsg [string-ref!]             ;char **
+	pzErrMsg [string-ptr!]             ;char **
 	return: [integer!]
 ]
 
@@ -8721,7 +8721,7 @@ sqlite3session_isempty: "sqlite3session_isempty" [
 
 
 sqlite3changeset_start: "sqlite3changeset_start" [
-	pp         [sqlite3-changeset-iter-ref!]; OUT: New changeset iterator handle 
+	pp         [sqlite3-changeset-iter-ptr!]; OUT: New changeset iterator handle 
 	nChangeset [integer!]              ; Size of changeset blob in bytes 
 	pChangeset [int-ptr!]              ; Pointer to blob containing changeset 
 	return: [integer!]
@@ -8782,7 +8782,7 @@ sqlite3changeset_next: "sqlite3changeset_next" [
 
 sqlite3changeset_op: "sqlite3changeset_op" [
 	pIter      [sqlite3-changeset-iter!]; Iterator object 
-	pzTab      [string-ref!]           ; OUT: Pointer to table name 
+	pzTab      [string-ptr!]           ; OUT: Pointer to table name 
 	pnCol      [int-ptr!]              ; OUT: Number of columns in table 
 	pOp        [int-ptr!]              ; OUT: SQLITE_INSERT, DELETE or UPDATE 
 	pbIndirect [int-ptr!]              ; OUT: True for an 'indirect' change 
@@ -8816,7 +8816,7 @@ sqlite3changeset_op: "sqlite3changeset_op" [
 
 sqlite3changeset_pk: "sqlite3changeset_pk" [
 	pIter   [sqlite3-changeset-iter!]  ; Iterator object 
-	pabPK   [string-ref!]              ; OUT: Array of boolean - true for PK cols 
+	pabPK   [string-ptr!]              ; OUT: Array of boolean - true for PK cols 
 	pnCol   [int-ptr!]                 ; OUT: Number of entries in output array 
 	return: [integer!]
 ]
@@ -8848,7 +8848,7 @@ sqlite3changeset_pk: "sqlite3changeset_pk" [
 sqlite3changeset_old: "sqlite3changeset_old" [
 	pIter   [sqlite3-changeset-iter!]  ; Changeset iterator 
 	iVal    [integer!]                 ; Column number 
-	ppValue [sqlite3-value-ref!]       ; OUT: Old value (or NULL pointer) 
+	ppValue [sqlite3-value-ptr!]       ; OUT: Old value (or NULL pointer) 
 	return: [integer!]
 ]
 
@@ -8882,7 +8882,7 @@ sqlite3changeset_old: "sqlite3changeset_old" [
 sqlite3changeset_new: "sqlite3changeset_new" [
 	pIter   [sqlite3-changeset-iter!]  ; Changeset iterator 
 	iVal    [integer!]                 ; Column number 
-	ppValue [sqlite3-value-ref!]       ; OUT: New value (or NULL pointer) 
+	ppValue [sqlite3-value-ptr!]       ; OUT: New value (or NULL pointer) 
 	return: [integer!]
 ]
 
@@ -8910,7 +8910,7 @@ sqlite3changeset_new: "sqlite3changeset_new" [
 sqlite3changeset_conflict: "sqlite3changeset_conflict" [
 	pIter   [sqlite3-changeset-iter!]  ; Changeset iterator 
 	iVal    [integer!]                 ; Column number 
-	ppValue [sqlite3-value-ref!]       ; OUT: Value from conflicting row 
+	ppValue [sqlite3-value-ptr!]       ; OUT: Value from conflicting row 
 	return: [integer!]
 ]
 
@@ -8992,7 +8992,7 @@ sqlite3changeset_finalize: "sqlite3changeset_finalize" [
 
 sqlite3changeset_invert: "sqlite3changeset_invert" [
 	nIn     [integer!]                 ;int
-	pIn     [byte-ptr!]                ; Input changeset 
+	pIn     [int-ptr!]                 ; Input changeset 
 	pnOut   [int-ptr!]                 ;int *
 	ppOut   [int-ptr!]                 ; OUT: Inverse of input 
 	return: [integer!]
@@ -9068,7 +9068,7 @@ sqlite3changeset_concat: "sqlite3changeset_concat" [
 
 
 sqlite3changegroup_new: "sqlite3changegroup_new" [
-	pp      [sqlite3-changegroup-ref!] ;sqlite3_changegroup **
+	pp      [sqlite3-changegroup-ptr!] ;sqlite3_changegroup **
 	return: [integer!]
 ]
 
@@ -9483,7 +9483,7 @@ sqlite3changeset_concat_strm: "sqlite3changeset_concat_strm" [
 	pInB    [int-ptr!]                 ;void *
 	xOutput [function! [
 		pOut   [int-ptr!] 
-		pData  [byte-ptr!] 
+		pData  [int-ptr!] 
 		nData  [integer!] 
 		return: [integer!]
 	]]
@@ -9500,7 +9500,7 @@ sqlite3changeset_invert_strm: "sqlite3changeset_invert_strm" [
 	pIn     [int-ptr!]                 ;void *
 	xOutput [function! [
 		pOut   [int-ptr!] 
-		pData  [byte-ptr!] 
+		pData  [int-ptr!] 
 		nData  [integer!] 
 		return: [integer!]
 	]]
@@ -9508,7 +9508,7 @@ sqlite3changeset_invert_strm: "sqlite3changeset_invert_strm" [
 	return: [integer!]
 ]
 sqlite3changeset_start_strm: "sqlite3changeset_start_strm" [
-	pp      [sqlite3-changeset-iter-ref!];sqlite3_changeset_iter **
+	pp      [sqlite3-changeset-iter-ptr!];sqlite3_changeset_iter **
 	xInput  [function! [
 		pIn    [int-ptr!] 
 		pData  [int-ptr!] 
@@ -9522,7 +9522,7 @@ sqlite3session_changeset_strm: "sqlite3session_changeset_strm" [
 	pSession [sqlite3-session!]        ;sqlite3_session *
 	xOutput  [function! [
 		pOut    [int-ptr!] 
-		pData   [byte-ptr!] 
+		pData   [int-ptr!] 
 		nData   [integer!] 
 		return: [integer!]
 	]]
@@ -9533,7 +9533,7 @@ sqlite3session_patchset_strm: "sqlite3session_patchset_strm" [
 	pSession [sqlite3-session!]        ;sqlite3_session *
 	xOutput  [function! [
 		pOut    [int-ptr!] 
-		pData   [byte-ptr!] 
+		pData   [int-ptr!] 
 		nData   [integer!] 
 		return: [integer!]
 	]]
@@ -9555,7 +9555,7 @@ sqlite3changegroup_output_strm: "sqlite3changegroup_output_strm" [
 	arg1    [sqlite3-changegroup!]     ;sqlite3_changegroup*
 	xOutput [function! [
 		pOut   [int-ptr!] 
-		pData  [byte-ptr!] 
+		pData  [int-ptr!] 
 		nData  [integer!] 
 		return: [integer!]
 	]]

--- a/Library/SWF/swf-tool.reds
+++ b/Library/SWF/swf-tool.reds
@@ -14,14 +14,14 @@ Red/System [
 #include %../os/time-elapsed.reds
 #include %swf-io.reds
 
-string-ref!:  alias struct! [value [c-string!]]
+#include %../os/definitions.reds ;common aliases and defines
 
 #import [
 	LIBC-file cdecl [
 		strtol: "strtol" [
 			;converts the initial part of the string to integer
 			string	[c-string!]
-			endptr  [string-ref!]
+			endptr  [string-ptr!]
 			base    [integer!]
 			return:	[integer!]
 		]
@@ -62,7 +62,7 @@ do-input: func [
 		str* actions n
 ][
 	n: 1
-	str*: declare string-ref!
+	str*: declare string-ptr!
 	actions: 0
 	file-name: null
 

--- a/Library/Steam/Steam-test.reds
+++ b/Library/Steam/Steam-test.reds
@@ -12,7 +12,7 @@ Red/System [
 init
 info
 
-data: declare binary-ref!
+data: declare binary-ptr!
 
 print-line ["exists hell.txt?  " file-exists? "hell.txt"]
 print-line ["exists hello.txt? " file-exists? "hello.txt"]

--- a/Library/Steam/Steam.red
+++ b/Library/Steam/Steam.red
@@ -7,7 +7,7 @@ Red [
 	
 ]
 #system [
-	binary-ref!:  alias struct! [value [byte-ptr!]]
+	binary-ptr!:  alias struct! [value [byte-ptr!]]
 
 	Steam: context [
 		#include %Steam.reds
@@ -60,11 +60,11 @@ Steam: context [
 			c-file [c-string!]
 			len    [integer!]
 			bytes  [integer!]
-			data   [binary-ref!]
+			data   [binary-ptr!]
 			bin    [red-binary!]
 	][
 		len: -1
-		data: declare binary-ref!
+		data: declare binary-ptr!
 		c-file:	unicode/to-utf8 file :len
 		
 		bytes: Steam/file-read c-file data

--- a/Library/Steam/Steam.reds
+++ b/Library/Steam/Steam.reds
@@ -9,8 +9,6 @@ Red/System [
 
 #include %SteamAPI/Steam-API.reds
 
-binary-ref!:  alias struct! [value [byte-ptr!]]
-
 isReady: false
 
 init: func[
@@ -30,7 +28,7 @@ list-friends: func[
 	type [integer!]
 	/local
 		num [integer!]
-		id  [uint64! value]
+		id  [uint64-value!]
 		name [c-string!]
 ][
 	num: SteamAPI_ISteamFriends_GetFriendCount ISteamFriends type
@@ -49,7 +47,7 @@ file-write: func[file [c-string!] data [byte-ptr!] length [integer!] return: [lo
 ]
 file-read: func[
 	file [c-string!]
-	data [binary-ref!]
+	data [binary-ptr!]
 	return: [integer!]
 	/local
 		size   [integer!]
@@ -93,8 +91,8 @@ list-files: func[
 
 info: func[
 	/local
-		total     [uint64!]
-		available [uint64!]
+		total     [uint64-value!]
+		available [uint64-value!]
 		res       [logic!]
 ][
 	if any [isReady init] [

--- a/Library/Steam/SteamAPI/Steam-API.reds
+++ b/Library/Steam/SteamAPI/Steam-API.reds
@@ -14,6 +14,8 @@ Red/System [
 	#default  [ #define STEAM_LIBRARY "libsteam_api.so"    ]
 ]
 
+#include %../../os/definitions.reds ;common aliases and defines
+
 #define ISteamClient!             int-ptr!
 #define ISteamUser!               int-ptr!
 #define ISteamFriends!            int-ptr!
@@ -43,19 +45,9 @@ Red/System [
 #define ISteamGameServerStats!    int-ptr!
 #define ISteamGameServerItem!     int-ptr!
 
-int64!:  alias struct! [lo [integer!] hi [integer!]] ;@@ must be changed once we will get real integer64! type
-uin16!:  alias struct! [lo [byte!] hi [byte!]]       ;@@ must be changed once we will get real integer16! type
-
-#define uint64! int64!
-#define uint64-ref! uint64!
-int64-ref!:  alias struct! [value [int64!]]
-logic-ref!:  alias struct! [value [logic!]]
-string-ref!:  alias struct! [value [c-string!]]
-
-#define uint16! integer! ;@@ must be changed once we will get real integer16! type
 
 CGameID!: alias struct! [
-	m_ulGameID [uint64! value]
+	m_ulGameID [uint64-value!]
 	m_gameID   [struct! [
 		m_nAppID [integer!]
 		m_nType  [integer!]
@@ -63,8 +55,8 @@ CGameID!: alias struct! [
 	]]
 ]
 
-#define CSteamID! [uint64! value]
-#define CSteamID-ref! uint64-ref!
+#define CSteamID! [uint64-value!]
+#define CSteamID-ptr! uint64-ptr!
 
 FriendGameInfo!: alias struct! [
 	m_gameID       [CGameID!]
@@ -80,7 +72,7 @@ LeaderboardEntry!: alias struct! [
 	m_nGlobalRank [integer!]
 	m_nScore      [integer!]
 	m_cDetails    [integer!]
-	m_hUGC        [uint64!]
+	m_hUGC        [uint64-value!]
 ]
 
 #include %Steam-enums.reds

--- a/Library/Steam/SteamAPI/Steam-Apps.reds
+++ b/Library/Steam/SteamAPI/Steam-Apps.reds
@@ -61,7 +61,7 @@ ISteamApps: declare ISteamApps!
 			instancePtr       [ISteamApps!]    ;intptr_t
 			iDLC              [integer!]       ;int
 			pAppID            [int-ptr!]       ;AppId_t *
-			pbAvailable       [logic-ref!];bool *
+			pbAvailable       [logic-ptr!];bool *
 			pchName           [c-string!]      ;char *
 			cchNameBufferSize [integer!]       ;int
 			return: [logic!]
@@ -110,7 +110,7 @@ ISteamApps: declare ISteamApps!
 		]
 		SteamAPI_ISteamApps_GetAppOwner: "SteamAPI_ISteamApps_GetAppOwner" [
 			instancePtr [ISteamApps!]          ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamApps_GetLaunchQueryParam: "SteamAPI_ISteamApps_GetLaunchQueryParam" [
 			instancePtr [ISteamApps!]          ;intptr_t
@@ -120,8 +120,8 @@ ISteamApps: declare ISteamApps!
 		SteamAPI_ISteamApps_GetDlcDownloadProgress: "SteamAPI_ISteamApps_GetDlcDownloadProgress" [
 			instancePtr        [ISteamApps!]   ;intptr_t
 			nAppID             [integer!]      ;AppId_t
-			punBytesDownloaded [uint64-ref!]   ;uint64 *
-			punBytesTotal      [uint64-ref!]   ;uint64 *
+			punBytesDownloaded [uint64-ptr!]   ;uint64 *
+			punBytesTotal      [uint64-ptr!]   ;uint64 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamApps_GetAppBuildId: "SteamAPI_ISteamApps_GetAppBuildId" [
@@ -134,7 +134,7 @@ ISteamApps: declare ISteamApps!
 		SteamAPI_ISteamApps_GetFileDetails: "SteamAPI_ISteamApps_GetFileDetails" [
 			instancePtr [ISteamApps!]          ;intptr_t
 			pszFileName [c-string!]            ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-Client.reds
+++ b/Library/Steam/SteamAPI/Steam-Client.reds
@@ -52,7 +52,7 @@ ISteamClient: declare ISteamClient!
 		SteamAPI_ISteamClient_SetLocalIPBinding: "SteamAPI_ISteamClient_SetLocalIPBinding" [
 			instancePtr [ISteamClient!]        ;intptr_t
 			unIP        [integer!]             ;uint32
-			usPort      [uint16!]              ;uint16
+			usPort      [uint16-value!]              ;uint16
 		]
 		SteamAPI_ISteamClient_GetISteamFriends: "SteamAPI_ISteamClient_GetISteamFriends" [
 			instancePtr [ISteamClient!]        ;intptr_t

--- a/Library/Steam/SteamAPI/Steam-Controller.reds
+++ b/Library/Steam/SteamAPI/Steam-Controller.reds
@@ -269,84 +269,84 @@ ISteamController: declare ISteamController!
 		]
 		SteamAPI_ISteamController_GetConnectedControllers: "SteamAPI_ISteamController_GetConnectedControllers" [
 			instancePtr [ISteamController!]    ;intptr_t
-			handlesOut  [uint64-ref!]          ;ControllerHandle_t *
+			handlesOut  [uint64-ptr!]          ;ControllerHandle_t *
 			return: [integer!]
 		]
 		SteamAPI_ISteamController_ShowBindingPanel: "SteamAPI_ISteamController_ShowBindingPanel" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamController_GetActionSetHandle: "SteamAPI_ISteamController_GetActionSetHandle" [
 			instancePtr      [ISteamController!];intptr_t
 			pszActionSetName [c-string!]       ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamController_ActivateActionSet: "SteamAPI_ISteamController_ActivateActionSet" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
-			actionSetHandle  [uint64! value]   ;ControllerActionSetHandle_t
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
+			actionSetHandle  [uint64-value!]   ;ControllerActionSetHandle_t
 		]
 		SteamAPI_ISteamController_GetCurrentActionSet: "SteamAPI_ISteamController_GetCurrentActionSet" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
-			return: [uint64! value]
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamController_GetDigitalActionHandle: "SteamAPI_ISteamController_GetDigitalActionHandle" [
 			instancePtr   [ISteamController!]  ;intptr_t
 			pszActionName [c-string!]          ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamController_GetDigitalActionOrigins: "SteamAPI_ISteamController_GetDigitalActionOrigins" [
 			instancePtr         [ISteamController!];intptr_t
-			controllerHandle    [uint64! value];ControllerHandle_t
-			actionSetHandle     [uint64! value];ControllerActionSetHandle_t
-			digitalActionHandle [uint64! value];ControllerDigitalActionHandle_t
+			controllerHandle    [uint64-value!];ControllerHandle_t
+			actionSetHandle     [uint64-value!];ControllerActionSetHandle_t
+			digitalActionHandle [uint64-value!];ControllerDigitalActionHandle_t
 			originsOut          [int-ptr!]     ;EControllerActionOrigin *
 			return: [integer!]
 		]
 		SteamAPI_ISteamController_GetAnalogActionHandle: "SteamAPI_ISteamController_GetAnalogActionHandle" [
 			instancePtr   [ISteamController!]  ;intptr_t
 			pszActionName [c-string!]          ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamController_GetAnalogActionOrigins: "SteamAPI_ISteamController_GetAnalogActionOrigins" [
 			instancePtr        [ISteamController!];intptr_t
-			controllerHandle   [uint64! value] ;ControllerHandle_t
-			actionSetHandle    [uint64! value] ;ControllerActionSetHandle_t
-			analogActionHandle [uint64! value] ;ControllerAnalogActionHandle_t
+			controllerHandle   [uint64-value!] ;ControllerHandle_t
+			actionSetHandle    [uint64-value!] ;ControllerActionSetHandle_t
+			analogActionHandle [uint64-value!] ;ControllerAnalogActionHandle_t
 			originsOut         [int-ptr!]      ;EControllerActionOrigin *
 			return: [integer!]
 		]
 		SteamAPI_ISteamController_StopAnalogActionMomentum: "SteamAPI_ISteamController_StopAnalogActionMomentum" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
-			eAction          [uint64! value]   ;ControllerAnalogActionHandle_t
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
+			eAction          [uint64-value!]   ;ControllerAnalogActionHandle_t
 		]
 		SteamAPI_ISteamController_TriggerHapticPulse: "SteamAPI_ISteamController_TriggerHapticPulse" [
 			instancePtr        [ISteamController!];intptr_t
-			controllerHandle   [uint64! value] ;ControllerHandle_t
+			controllerHandle   [uint64-value!] ;ControllerHandle_t
 			eTargetPad         [ESteamControllerPad!];ESteamControllerPad
-			usDurationMicroSec [uin16! value]        ;unsigned short
+			usDurationMicroSec [uint16-value!]        ;unsigned short
 		]
 		SteamAPI_ISteamController_TriggerRepeatedHapticPulse: {SteamAPI_ISteamController_TriggerRepeatedHapticPulse} [
 			instancePtr        [ISteamController!];intptr_t
-			controllerHandle   [uint64! value] ;ControllerHandle_t
+			controllerHandle   [uint64-value!] ;ControllerHandle_t
 			eTargetPad         [ESteamControllerPad!];ESteamControllerPad
-			usDurationMicroSec [uin16! value]        ;unsigned short
-			usOffMicroSec      [uin16! value]        ;unsigned short
-			unRepeat           [uin16! value]        ;unsigned short
+			usDurationMicroSec [uint16-value!]        ;unsigned short
+			usOffMicroSec      [uint16-value!]        ;unsigned short
+			unRepeat           [uint16-value!]        ;unsigned short
 			nFlags             [integer!]      ;unsigned int
 		]
 		SteamAPI_ISteamController_TriggerVibration: "SteamAPI_ISteamController_TriggerVibration" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
-			usLeftSpeed      [uin16! value]          ;unsigned short
-			usRightSpeed     [uin16! value]          ;unsigned short
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
+			usLeftSpeed      [uint16-value!]          ;unsigned short
+			usRightSpeed     [uint16-value!]          ;unsigned short
 		]
 		SteamAPI_ISteamController_SetLEDColor: "SteamAPI_ISteamController_SetLEDColor" [
 			instancePtr      [ISteamController!];intptr_t
-			controllerHandle [uint64! value]   ;ControllerHandle_t
+			controllerHandle [uint64-value!]   ;ControllerHandle_t
 			nColorR          [byte!]           ;uint8
 			nColorG          [byte!]           ;uint8
 			nColorB          [byte!]           ;uint8
@@ -354,18 +354,18 @@ ISteamController: declare ISteamController!
 		]
 		SteamAPI_ISteamController_GetGamepadIndexForController: {SteamAPI_ISteamController_GetGamepadIndexForController} [
 			instancePtr        [ISteamController!];intptr_t
-			ulControllerHandle [uint64! value] ;ControllerHandle_t
+			ulControllerHandle [uint64-value!] ;ControllerHandle_t
 			return: [integer!]
 		]
 		SteamAPI_ISteamController_GetControllerForGamepadIndex: {SteamAPI_ISteamController_GetControllerForGamepadIndex} [
 			instancePtr [ISteamController!]    ;intptr_t
 			nIndex      [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamController_ShowDigitalActionOrigins: "SteamAPI_ISteamController_ShowDigitalActionOrigins" [
 			instancePtr         [ISteamController!];intptr_t
-			controllerHandle    [uint64! value];ControllerHandle_t
-			digitalActionHandle [uint64! value];ControllerDigitalActionHandle_t
+			controllerHandle    [uint64-value!];ControllerHandle_t
+			digitalActionHandle [uint64-value!];ControllerDigitalActionHandle_t
 			flScale             [float32!]     ;float
 			flXPosition         [float32!]     ;float
 			flYPosition         [float32!]     ;float
@@ -373,8 +373,8 @@ ISteamController: declare ISteamController!
 		]
 		SteamAPI_ISteamController_ShowAnalogActionOrigins: "SteamAPI_ISteamController_ShowAnalogActionOrigins" [
 			instancePtr        [ISteamController!];intptr_t
-			controllerHandle   [uint64! value] ;ControllerHandle_t
-			analogActionHandle [uint64! value] ;ControllerAnalogActionHandle_t
+			controllerHandle   [uint64-value!] ;ControllerHandle_t
+			analogActionHandle [uint64-value!] ;ControllerAnalogActionHandle_t
 			flScale            [float32!]      ;float
 			flXPosition        [float32!]      ;float
 			flYPosition        [float32!]      ;float

--- a/Library/Steam/SteamAPI/Steam-Friends.reds
+++ b/Library/Steam/SteamAPI/Steam-Friends.reds
@@ -66,7 +66,7 @@ ISteamFriends: declare ISteamFriends!
 #define k_cFriendsGroupLimit  100
 
 ; invalid friends group identifier constant
-#define k_FriendsGroupID_Invalid -1 ;int16!
+#define k_FriendsGroupID_Invalid -1 ;@@ int16-value!
 
 #define k_cEnumerateFollowersMax  50
 
@@ -87,7 +87,7 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_SetPersonaName: "SteamAPI_ISteamFriends_SetPersonaName" [
 			instancePtr    [ISteamFriends!]    ;intptr_t
 			pchPersonaName [c-string!]         ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetPersonaState: "SteamAPI_ISteamFriends_GetPersonaState" [
 			instancePtr [ISteamFriends!]       ;intptr_t
@@ -102,7 +102,7 @@ ISteamFriends: declare ISteamFriends!
 			instancePtr  [ISteamFriends!]      ;intptr_t
 			iFriend      [integer!]            ;int
 			iFriendFlags [integer!]            ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetFriendRelationship: "SteamAPI_ISteamFriends_GetFriendRelationship" [
 			instancePtr   [ISteamFriends!]     ;intptr_t
@@ -148,22 +148,22 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_GetFriendsGroupIDByIndex: "SteamAPI_ISteamFriends_GetFriendsGroupIDByIndex" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			iFG         [integer!]             ;int
-			return: [int16!]
+			return: [int16-value!]
 		]
 		SteamAPI_ISteamFriends_GetFriendsGroupName: "SteamAPI_ISteamFriends_GetFriendsGroupName" [
 			instancePtr    [ISteamFriends!]    ;intptr_t
-			friendsGroupID [int16!]            ;FriendsGroupID_t
+			friendsGroupID [int16-value!]      ;FriendsGroupID_t
 			return: [c-string!]
 		]
 		SteamAPI_ISteamFriends_GetFriendsGroupMembersCount: "SteamAPI_ISteamFriends_GetFriendsGroupMembersCount" [
 			instancePtr    [ISteamFriends!]    ;intptr_t
-			friendsGroupID [int16!]            ;FriendsGroupID_t
+			friendsGroupID [int16-value!]      ;FriendsGroupID_t
 			return: [integer!]
 		]
 		SteamAPI_ISteamFriends_GetFriendsGroupMembersList: "SteamAPI_ISteamFriends_GetFriendsGroupMembersList" [
 			instancePtr        [ISteamFriends!];intptr_t
-			friendsGroupID     [int16!]        ;FriendsGroupID_t
-			pOutSteamIDMembers [CSteamID-ref!] ;class CSteamID *
+			friendsGroupID     [int16-value!]  ;FriendsGroupID_t
+			pOutSteamIDMembers [CSteamID-ptr!] ;class CSteamID *
 			nMembersCount      [integer!]      ;int
 		]
 		SteamAPI_ISteamFriends_HasFriend: "SteamAPI_ISteamFriends_HasFriend" [
@@ -179,7 +179,7 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_GetClanByIndex: "SteamAPI_ISteamFriends_GetClanByIndex" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			iClan       [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetClanName: "SteamAPI_ISteamFriends_GetClanName" [
 			instancePtr [ISteamFriends!]       ;intptr_t
@@ -201,9 +201,9 @@ ISteamFriends: declare ISteamFriends!
 		]
 		SteamAPI_ISteamFriends_DownloadClanActivityCounts: "SteamAPI_ISteamFriends_DownloadClanActivityCounts" [
 			instancePtr     [ISteamFriends!]   ;intptr_t
-			psteamIDClans   [CSteamID-ref!]    ;class CSteamID *
+			psteamIDClans   [CSteamID-ptr!]    ;class CSteamID *
 			cClansToRequest [integer!]         ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetFriendCountFromSource: "SteamAPI_ISteamFriends_GetFriendCountFromSource" [
 			instancePtr   [ISteamFriends!]     ;intptr_t
@@ -214,7 +214,7 @@ ISteamFriends: declare ISteamFriends!
 			instancePtr   [ISteamFriends!]     ;intptr_t
 			steamIDSource [CSteamID!]          ;class CSteamID
 			iFriend       [integer!]           ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_IsUserInSource: "SteamAPI_ISteamFriends_IsUserInSource" [
 			instancePtr   [ISteamFriends!]     ;intptr_t
@@ -277,12 +277,12 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_RequestClanOfficerList: "SteamAPI_ISteamFriends_RequestClanOfficerList" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetClanOwner: "SteamAPI_ISteamFriends_GetClanOwner" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetClanOfficerCount: "SteamAPI_ISteamFriends_GetClanOfficerCount" [
 			instancePtr [ISteamFriends!]       ;intptr_t
@@ -293,7 +293,7 @@ ISteamFriends: declare ISteamFriends!
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
 			iOfficer    [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetUserRestrictions: "SteamAPI_ISteamFriends_GetUserRestrictions" [
 			instancePtr [ISteamFriends!]       ;intptr_t
@@ -342,7 +342,7 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_GetCoplayFriend: "SteamAPI_ISteamFriends_GetCoplayFriend" [
 			instancePtr   [ISteamFriends!]     ;intptr_t
 			iCoplayFriend [integer!]           ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_GetFriendCoplayTime: "SteamAPI_ISteamFriends_GetFriendCoplayTime" [
 			instancePtr   [ISteamFriends!]     ;intptr_t
@@ -357,7 +357,7 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_JoinClanChatRoom: "SteamAPI_ISteamFriends_JoinClanChatRoom" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_LeaveClanChatRoom: "SteamAPI_ISteamFriends_LeaveClanChatRoom" [
 			instancePtr [ISteamFriends!]       ;intptr_t
@@ -373,7 +373,7 @@ ISteamFriends: declare ISteamFriends!
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
 			iUser       [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_SendClanChatMessage: "SteamAPI_ISteamFriends_SendClanChatMessage" [
 			instancePtr     [ISteamFriends!]   ;intptr_t
@@ -388,7 +388,7 @@ ISteamFriends: declare ISteamFriends!
 			prgchText       [byte-ptr!]        ;void *
 			cchTextMax      [integer!]         ;int
 			peChatEntryType [int-ptr!]         ;EChatEntryType *
-			psteamidChatter [CSteamID-ref!]    ;class CSteamID *
+			psteamidChatter [CSteamID-ptr!]    ;class CSteamID *
 			return: [integer!]
 		]
 		SteamAPI_ISteamFriends_IsClanChatAdmin: "SteamAPI_ISteamFriends_IsClanChatAdmin" [
@@ -435,17 +435,17 @@ ISteamFriends: declare ISteamFriends!
 		SteamAPI_ISteamFriends_GetFollowerCount: "SteamAPI_ISteamFriends_GetFollowerCount" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamID     [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_IsFollowing: "SteamAPI_ISteamFriends_IsFollowing" [
 			instancePtr [ISteamFriends!]       ;intptr_t
 			steamID     [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamFriends_EnumerateFollowingList: "SteamAPI_ISteamFriends_EnumerateFollowingList" [
 			instancePtr  [ISteamFriends!]      ;intptr_t
 			unStartIndex [integer!]            ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-GameServer.reds
+++ b/Library/Steam/SteamAPI/Steam-GameServer.reds
@@ -13,8 +13,8 @@ ISteamGameServer: declare ISteamGameServer!
 		SteamAPI_ISteamGameServer_InitGameServer: "SteamAPI_ISteamGameServer_InitGameServer" [
 			instancePtr      [ISteamGameServer!];intptr_t
 			unIP             [integer!]        ;uint32
-			usGamePort       [uint16!]         ;uint16
-			usQueryPort      [uint16!]         ;uint16
+			usGamePort       [uint16-value!]         ;uint16
+			usQueryPort      [uint16-value!]         ;uint16
 			unFlags          [integer!]        ;uint32
 			nGameAppId       [integer!]        ;AppId_t
 			pchVersionString [c-string!]       ;const char *
@@ -56,7 +56,7 @@ ISteamGameServer: declare ISteamGameServer!
 		]
 		SteamAPI_ISteamGameServer_GetSteamID: "SteamAPI_ISteamGameServer_GetSteamID" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamGameServer_WasRestartRequested: "SteamAPI_ISteamGameServer_WasRestartRequested" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
@@ -84,7 +84,7 @@ ISteamGameServer: declare ISteamGameServer!
 		]
 		SteamAPI_ISteamGameServer_SetSpectatorPort: "SteamAPI_ISteamGameServer_SetSpectatorPort" [
 			instancePtr     [ISteamGameServer!];intptr_t
-			unSpectatorPort [uint16!]          ;uint16
+			unSpectatorPort [uint16-value!]          ;uint16
 		]
 		SteamAPI_ISteamGameServer_SetSpectatorServerName: "SteamAPI_ISteamGameServer_SetSpectatorServerName" [
 			instancePtr         [ISteamGameServer!];intptr_t
@@ -115,12 +115,12 @@ ISteamGameServer: declare ISteamGameServer!
 			unIPClient      [integer!]         ;uint32
 			pvAuthBlob      [byte-ptr!]        ;const void *
 			cubAuthBlobSize [integer!]         ;uint32
-			pSteamIDUser    [CSteamID-ref!]    ;class CSteamID *
+			pSteamIDUser    [CSteamID-ptr!]    ;class CSteamID *
 			return: [logic!]
 		]
 		SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection: {SteamAPI_ISteamGameServer_CreateUnauthenticatedUserConnection} [
 			instancePtr [ISteamGameServer!]    ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamGameServer_SendUserDisconnect: "SteamAPI_ISteamGameServer_SendUserDisconnect" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
@@ -172,7 +172,7 @@ ISteamGameServer: declare ISteamGameServer!
 		]
 		SteamAPI_ISteamGameServer_GetServerReputation: "SteamAPI_ISteamGameServer_GetServerReputation" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamGameServer_GetPublicIP: "SteamAPI_ISteamGameServer_GetPublicIP" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
@@ -183,7 +183,7 @@ ISteamGameServer: declare ISteamGameServer!
 			pData       [byte-ptr!]            ;const void *
 			cbData      [integer!]             ;int
 			srcIP       [integer!]             ;uint32
-			srcPort     [uint16!]              ;uint16
+			srcPort     [uint16-value!]              ;uint16
 			return: [logic!]
 		]
 		SteamAPI_ISteamGameServer_GetNextOutgoingPacket: "SteamAPI_ISteamGameServer_GetNextOutgoingPacket" [
@@ -191,7 +191,7 @@ ISteamGameServer: declare ISteamGameServer!
 			pOut        [byte-ptr!]            ;void *
 			cbMaxOut    [integer!]             ;int
 			pNetAdr     [int-ptr!]             ;uint32 *
-			pPort       [pointer! [uint16!]]   ;uint16 *
+			pPort       [uint16-ptr!]           ;uint16 *
 			return: [integer!]
 		]
 		SteamAPI_ISteamGameServer_EnableHeartbeats: "SteamAPI_ISteamGameServer_EnableHeartbeats" [
@@ -208,12 +208,12 @@ ISteamGameServer: declare ISteamGameServer!
 		SteamAPI_ISteamGameServer_AssociateWithClan: "SteamAPI_ISteamGameServer_AssociateWithClan" [
 			instancePtr [ISteamGameServer!]    ;intptr_t
 			steamIDClan [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamGameServer_ComputeNewPlayerCompatibility: {SteamAPI_ISteamGameServer_ComputeNewPlayerCompatibility} [
 			instancePtr      [ISteamGameServer!];intptr_t
 			steamIDNewPlayer [CSteamID!]       ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-GameServerStats.reds
+++ b/Library/Steam/SteamAPI/Steam-GameServerStats.reds
@@ -13,7 +13,7 @@ ISteamGameServerStats: declare ISteamGameServerStats!
 		SteamAPI_ISteamGameServerStats_RequestUserStats: "SteamAPI_ISteamGameServerStats_RequestUserStats" [
 			instancePtr [ISteamGameServerStats!];intptr_t
 			steamIDUser [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamGameServerStats_GetUserStat: "SteamAPI_ISteamGameServerStats_GetUserStat" [
 			instancePtr [ISteamGameServerStats!];intptr_t
@@ -33,7 +33,7 @@ ISteamGameServerStats: declare ISteamGameServerStats!
 			instancePtr [ISteamGameServerStats!];intptr_t
 			steamIDUser [CSteamID!]            ;class CSteamID
 			pchName     [c-string!]            ;const char *
-			pbAchieved  [logic-ref!]    ;bool *
+			pbAchieved  [logic-ptr!]    ;bool *
 			return: [logic!]
 		]
 		SteamAPI_ISteamGameServerStats_SetUserStat: "SteamAPI_ISteamGameServerStats_SetUserStat" [
@@ -73,7 +73,7 @@ ISteamGameServerStats: declare ISteamGameServerStats!
 		SteamAPI_ISteamGameServerStats_StoreUserStats: "SteamAPI_ISteamGameServerStats_StoreUserStats" [
 			instancePtr [ISteamGameServerStats!];intptr_t
 			steamIDUser [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-HTMLSurface.reds
+++ b/Library/Steam/SteamAPI/Steam-HTMLSurface.reds
@@ -36,7 +36,7 @@ Red/System [
 			instancePtr  [ISteamHTMLSurface!]  ;intptr_t
 			pchUserAgent [c-string!]           ;const char *
 			pchUserCSS   [c-string!]           ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamHTMLSurface_RemoveBrowser: "SteamAPI_ISteamHTMLSurface_RemoveBrowser" [
 			instancePtr     [ISteamHTMLSurface!];intptr_t

--- a/Library/Steam/SteamAPI/Steam-HTTP.reds
+++ b/Library/Steam/SteamAPI/Steam-HTTP.reds
@@ -101,7 +101,7 @@ ISteamHTTP: declare ISteamHTTP!
 		SteamAPI_ISteamHTTP_SetHTTPRequestContextValue: "SteamAPI_ISteamHTTP_SetHTTPRequestContextValue" [
 			instancePtr    [ISteamHTTP!]       ;intptr_t
 			hRequest       [integer!]          ;HTTPRequestHandle
-			ulContextValue [uint64! value]     ;uint64
+			ulContextValue [uint64-value!]     ;uint64
 			return: [logic!]
 		]
 		SteamAPI_ISteamHTTP_SetHTTPRequestNetworkActivityTimeout: {SteamAPI_ISteamHTTP_SetHTTPRequestNetworkActivityTimeout} [
@@ -127,13 +127,13 @@ ISteamHTTP: declare ISteamHTTP!
 		SteamAPI_ISteamHTTP_SendHTTPRequest: "SteamAPI_ISteamHTTP_SendHTTPRequest" [
 			instancePtr [ISteamHTTP!]          ;intptr_t
 			hRequest    [integer!]             ;HTTPRequestHandle
-			pCallHandle [uint64-ref!]          ;SteamAPICall_t *
+			pCallHandle [uint64-ptr!]          ;SteamAPICall_t *
 			return: [logic!]
 		]
 		SteamAPI_ISteamHTTP_SendHTTPRequestAndStreamResponse: {SteamAPI_ISteamHTTP_SendHTTPRequestAndStreamResponse} [
 			instancePtr [ISteamHTTP!]          ;intptr_t
 			hRequest    [integer!]             ;HTTPRequestHandle
-			pCallHandle [uint64-ref!]          ;SteamAPICall_t *
+			pCallHandle [uint64-ptr!]          ;SteamAPICall_t *
 			return: [logic!]
 		]
 		SteamAPI_ISteamHTTP_DeferHTTPRequest: "SteamAPI_ISteamHTTP_DeferHTTPRequest" [
@@ -246,7 +246,7 @@ ISteamHTTP: declare ISteamHTTP!
 		SteamAPI_ISteamHTTP_GetHTTPRequestWasTimedOut: "SteamAPI_ISteamHTTP_GetHTTPRequestWasTimedOut" [
 			instancePtr   [ISteamHTTP!]        ;intptr_t
 			hRequest      [integer!]           ;HTTPRequestHandle
-			pbWasTimedOut [logic-ref!]  ;bool *
+			pbWasTimedOut [logic-ptr!]  ;bool *
 			return: [logic!]
 		]
 	]

--- a/Library/Steam/SteamAPI/Steam-Inventory.reds
+++ b/Library/Steam/SteamAPI/Steam-Inventory.reds
@@ -45,7 +45,7 @@ ISteamInventory: declare ISteamInventory!
 		SteamAPI_ISteamInventory_GetItemsByID: "SteamAPI_ISteamInventory_GetItemsByID" [
 			instancePtr        [ISteamInventory!];intptr_t
 			pResultHandle      [int-ptr!]      ;SteamInventoryResult_t *
-			pInstanceIDs       [uint64-ref!]   ;const SteamItemInstanceID_t *
+			pInstanceIDs       [uint64-ptr!]   ;const SteamItemInstanceID_t *
 			unCountInstanceIDs [integer!]      ;uint32
 			return: [logic!]
 		]
@@ -93,7 +93,7 @@ ISteamInventory: declare ISteamInventory!
 		SteamAPI_ISteamInventory_ConsumeItem: "SteamAPI_ISteamInventory_ConsumeItem" [
 			instancePtr   [ISteamInventory!]   ;intptr_t
 			pResultHandle [int-ptr!]           ;SteamInventoryResult_t *
-			itemConsume   [uint64! value]      ;SteamItemInstanceID_t
+			itemConsume   [uint64-value!]      ;SteamItemInstanceID_t
 			unQuantity    [integer!]           ;uint32
 			return: [logic!]
 		]
@@ -103,7 +103,7 @@ ISteamInventory: declare ISteamInventory!
 			pArrayGenerate      [int-ptr!]     ;const SteamItemDef_t *
 			punArrayGenerateQuantity[int-ptr!] ;const uint32 *
 			unArrayGenerateLength[integer!]    ;uint32
-			pArrayDestroy       [uint64-ref!]  ;const SteamItemInstanceID_t *
+			pArrayDestroy       [uint64-ptr!]  ;const SteamItemInstanceID_t *
 			punArrayDestroyQuantity[int-ptr!]  ;const uint32 *
 			unArrayDestroyLength[integer!]     ;uint32
 			return: [logic!]
@@ -111,9 +111,9 @@ ISteamInventory: declare ISteamInventory!
 		SteamAPI_ISteamInventory_TransferItemQuantity: "SteamAPI_ISteamInventory_TransferItemQuantity" [
 			instancePtr   [ISteamInventory!]   ;intptr_t
 			pResultHandle [int-ptr!]           ;SteamInventoryResult_t *
-			itemIdSource  [uint64! value]      ;SteamItemInstanceID_t
+			itemIdSource  [uint64-value!]      ;SteamItemInstanceID_t
 			unQuantity    [integer!]           ;uint32
-			itemIdDest    [uint64! value]      ;SteamItemInstanceID_t
+			itemIdDest    [uint64-value!]      ;SteamItemInstanceID_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamInventory_SendItemDropHeartbeat: "SteamAPI_ISteamInventory_SendItemDropHeartbeat" [
@@ -129,10 +129,10 @@ ISteamInventory: declare ISteamInventory!
 			instancePtr         [ISteamInventory!];intptr_t
 			pResultHandle       [int-ptr!]     ;SteamInventoryResult_t *
 			steamIDTradePartner [CSteamID!]    ;class CSteamID
-			pArrayGive          [uint64-ref!]  ;const SteamItemInstanceID_t *
+			pArrayGive          [uint64-ptr!]  ;const SteamItemInstanceID_t *
 			pArrayGiveQuantity  [int-ptr!]     ;const uint32 *
 			nArrayGiveLength    [integer!]     ;uint32
-			pArrayGet           [uint64-ref!]  ;const SteamItemInstanceID_t *
+			pArrayGet           [uint64-ptr!]  ;const SteamItemInstanceID_t *
 			pArrayGetQuantity   [int-ptr!]     ;const uint32 *
 			nArrayGetLength     [integer!]     ;uint32
 			return: [logic!]
@@ -158,7 +158,7 @@ ISteamInventory: declare ISteamInventory!
 		SteamAPI_ISteamInventory_RequestEligiblePromoItemDefinitionsIDs: {SteamAPI_ISteamInventory_RequestEligiblePromoItemDefinitionsIDs} [
 			instancePtr [ISteamInventory!]     ;intptr_t
 			steamID     [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamInventory_GetEligiblePromoItemDefinitionIDs: {SteamAPI_ISteamInventory_GetEligiblePromoItemDefinitionIDs} [
 			instancePtr         [ISteamInventory!];intptr_t

--- a/Library/Steam/SteamAPI/Steam-Matchmaking.reds
+++ b/Library/Steam/SteamAPI/Steam-Matchmaking.reds
@@ -47,8 +47,8 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			iGame               [integer!]     ;int
 			pnAppID             [int-ptr!]     ;AppId_t *
 			pnIP                [int-ptr!]     ;uint32 *
-			pnConnPort          [pointer! [uint16!]];uint16 *
-			pnQueryPort         [pointer! [uint16!]];uint16 *
+			pnConnPort          [uint16-ptr!];uint16 *
+			pnQueryPort         [uint16-ptr!];uint16 *
 			punFlags            [int-ptr!]     ;uint32 *
 			pRTime32LastPlayedOnServer[int-ptr!];uint32 *
 			return: [logic!]
@@ -57,8 +57,8 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			instancePtr         [ISteamMatchmaking!];intptr_t
 			nAppID              [integer!]     ;AppId_t
 			nIP                 [integer!]     ;uint32
-			nConnPort           [uint16!]      ;uint16
-			nQueryPort          [uint16!]      ;uint16
+			nConnPort           [uint16-value!]      ;uint16
+			nQueryPort          [uint16-value!]      ;uint16
 			unFlags             [integer!]     ;uint32
 			rTime32LastPlayedOnServer[integer!];uint32
 			return: [integer!]
@@ -67,14 +67,14 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			instancePtr [ISteamMatchmaking!]   ;intptr_t
 			nAppID      [integer!]             ;AppId_t
 			nIP         [integer!]             ;uint32
-			nConnPort   [uint16!]              ;uint16
-			nQueryPort  [uint16!]              ;uint16
+			nConnPort   [uint16-value!]              ;uint16
+			nQueryPort  [uint16-value!]              ;uint16
 			unFlags     [integer!]             ;uint32
 			return: [logic!]
 		]
 		SteamAPI_ISteamMatchmaking_RequestLobbyList: "SteamAPI_ISteamMatchmaking_RequestLobbyList" [
 			instancePtr [ISteamMatchmaking!]   ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_AddRequestLobbyListStringFilter: {SteamAPI_ISteamMatchmaking_AddRequestLobbyListStringFilter} [
 			instancePtr     [ISteamMatchmaking!];intptr_t
@@ -112,18 +112,18 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 		SteamAPI_ISteamMatchmaking_GetLobbyByIndex: "SteamAPI_ISteamMatchmaking_GetLobbyByIndex" [
 			instancePtr [ISteamMatchmaking!]   ;intptr_t
 			iLobby      [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_CreateLobby: "SteamAPI_ISteamMatchmaking_CreateLobby" [
 			instancePtr [ISteamMatchmaking!]   ;intptr_t
 			eLobbyType  [ELobbyType!]          ;ELobbyType
 			cMaxMembers [integer!]             ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_JoinLobby: "SteamAPI_ISteamMatchmaking_JoinLobby" [
 			instancePtr  [ISteamMatchmaking!]  ;intptr_t
 			steamIDLobby [CSteamID!]           ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_LeaveLobby: "SteamAPI_ISteamMatchmaking_LeaveLobby" [
 			instancePtr  [ISteamMatchmaking!]  ;intptr_t
@@ -144,7 +144,7 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			instancePtr  [ISteamMatchmaking!]  ;intptr_t
 			steamIDLobby [CSteamID!]           ;class CSteamID
 			iMember      [integer!]            ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_GetLobbyData: "SteamAPI_ISteamMatchmaking_GetLobbyData" [
 			instancePtr  [ISteamMatchmaking!]  ;intptr_t
@@ -204,7 +204,7 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			instancePtr     [ISteamMatchmaking!];intptr_t
 			steamIDLobby    [CSteamID!]        ;class CSteamID
 			iChatID         [integer!]         ;int
-			pSteamIDUser    [CSteamID-ref!]    ;class CSteamID *
+			pSteamIDUser    [CSteamID-ptr!]    ;class CSteamID *
 			pvData          [byte-ptr!]        ;void *
 			cubData         [integer!]         ;int
 			peChatEntryType [int-ptr!]         ;EChatEntryType *
@@ -219,15 +219,15 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 			instancePtr       [ISteamMatchmaking!];intptr_t
 			steamIDLobby      [CSteamID!]      ;class CSteamID
 			unGameServerIP    [integer!]       ;uint32
-			unGameServerPort  [uint16!]        ;uint16
+			unGameServerPort  [uint16-value!]        ;uint16
 			steamIDGameServer [CSteamID!]      ;class CSteamID
 		]
 		SteamAPI_ISteamMatchmaking_GetLobbyGameServer: "SteamAPI_ISteamMatchmaking_GetLobbyGameServer" [
 			instancePtr        [ISteamMatchmaking!];intptr_t
 			steamIDLobby       [CSteamID!]     ;class CSteamID
 			punGameServerIP    [int-ptr!]      ;uint32 *
-			punGameServerPort  [pointer! [uint16!]];uint16 *
-			psteamIDGameServer [CSteamID-ref!] ;class CSteamID *
+			punGameServerPort  [uint16-ptr!];uint16 *
+			psteamIDGameServer [CSteamID-ptr!] ;class CSteamID *
 			return: [logic!]
 		]
 		SteamAPI_ISteamMatchmaking_SetLobbyMemberLimit: "SteamAPI_ISteamMatchmaking_SetLobbyMemberLimit" [
@@ -256,7 +256,7 @@ ISteamMatchmaking: declare ISteamMatchmaking!
 		SteamAPI_ISteamMatchmaking_GetLobbyOwner: "SteamAPI_ISteamMatchmaking_GetLobbyOwner" [
 			instancePtr  [ISteamMatchmaking!]  ;intptr_t
 			steamIDLobby [CSteamID!]           ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamMatchmaking_SetLobbyOwner: "SteamAPI_ISteamMatchmaking_SetLobbyOwner" [
 			instancePtr     [ISteamMatchmaking!];intptr_t

--- a/Library/Steam/SteamAPI/Steam-MatchmakingServers.reds
+++ b/Library/Steam/SteamAPI/Steam-MatchmakingServers.reds
@@ -92,21 +92,21 @@ ISteamMatchmakingServers: declare ISteamMatchmakingServers!
 		SteamAPI_ISteamMatchmakingServers_PingServer: "SteamAPI_ISteamMatchmakingServers_PingServer" [
 			instancePtr         [ISteamMatchmakingServers!];intptr_t
 			unIP                [integer!]     ;uint32
-			usPort              [uint16!]      ;uint16
+			usPort              [uint16-value!]      ;uint16
 			pRequestServersResponse[int-ptr!]  ;class ISteamMatchmakingPingResponse *
 			return: [integer!]
 		]
 		SteamAPI_ISteamMatchmakingServers_PlayerDetails: "SteamAPI_ISteamMatchmakingServers_PlayerDetails" [
 			instancePtr         [ISteamMatchmakingServers!];intptr_t
 			unIP                [integer!]     ;uint32
-			usPort              [uint16!]      ;uint16
+			usPort              [uint16-value!]      ;uint16
 			pRequestServersResponse[int-ptr!]  ;class ISteamMatchmakingPlayersResponse *
 			return: [integer!]
 		]
 		SteamAPI_ISteamMatchmakingServers_ServerRules: "SteamAPI_ISteamMatchmakingServers_ServerRules" [
 			instancePtr         [ISteamMatchmakingServers!];intptr_t
 			unIP                [integer!]     ;uint32
-			usPort              [uint16!]      ;uint16
+			usPort              [uint16-value!]      ;uint16
 			pRequestServersResponse[int-ptr!]  ;class ISteamMatchmakingRulesResponse *
 			return: [integer!]
 		]

--- a/Library/Steam/SteamAPI/Steam-Networking.reds
+++ b/Library/Steam/SteamAPI/Steam-Networking.reds
@@ -102,7 +102,7 @@ ISteamNetworking: declare ISteamNetworking!
 			pubDest        [byte-ptr!]         ;void *
 			cubDest        [integer!]          ;uint32
 			pcubMsgSize    [int-ptr!]          ;uint32 *
-			psteamIDRemote [CSteamID-ref!]     ;class CSteamID *
+			psteamIDRemote [CSteamID-ptr!]     ;class CSteamID *
 			nChannel       [integer!]          ;int
 			return: [logic!]
 		]
@@ -137,7 +137,7 @@ ISteamNetworking: declare ISteamNetworking!
 			instancePtr         [ISteamNetworking!];intptr_t
 			nVirtualP2PPort     [integer!]     ;int
 			nIP                 [integer!]     ;uint32
-			nPort               [uint16!]      ;uint16
+			nPort               [uint16-value!]      ;uint16
 			bAllowUseOfPacketRelay[logic!]     ;bool
 			return: [integer!]
 		]
@@ -152,7 +152,7 @@ ISteamNetworking: declare ISteamNetworking!
 		SteamAPI_ISteamNetworking_CreateConnectionSocket: "SteamAPI_ISteamNetworking_CreateConnectionSocket" [
 			instancePtr [ISteamNetworking!]    ;intptr_t
 			nIP         [integer!]             ;uint32
-			nPort       [uint16!]              ;uint16
+			nPort       [uint16-value!]              ;uint16
 			nTimeoutSec [integer!]             ;int
 			return: [integer!]
 		]
@@ -209,17 +209,17 @@ ISteamNetworking: declare ISteamNetworking!
 		SteamAPI_ISteamNetworking_GetSocketInfo: "SteamAPI_ISteamNetworking_GetSocketInfo" [
 			instancePtr    [ISteamNetworking!] ;intptr_t
 			hSocket        [integer!]          ;SNetSocket_t
-			pSteamIDRemote [CSteamID-ref!]     ;class CSteamID *
+			pSteamIDRemote [CSteamID-ptr!]     ;class CSteamID *
 			peSocketStatus [int-ptr!]          ;int *
 			punIPRemote    [int-ptr!]          ;uint32 *
-			punPortRemote  [pointer! [uint16!]];uint16 *
+			punPortRemote  [uint16-ptr!];uint16 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamNetworking_GetListenSocketInfo: "SteamAPI_ISteamNetworking_GetListenSocketInfo" [
 			instancePtr   [ISteamNetworking!]  ;intptr_t
 			hListenSocket [integer!]           ;SNetListenSocket_t
 			pnIP          [int-ptr!]           ;uint32 *
-			pnPort        [pointer! [uint16!]] ;uint16 *
+			pnPort        [uint16-ptr!] ;uint16 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamNetworking_GetSocketConnectionType: "SteamAPI_ISteamNetworking_GetSocketConnectionType" [

--- a/Library/Steam/SteamAPI/Steam-RemoteStorage.reds
+++ b/Library/Steam/SteamAPI/Steam-RemoteStorage.reds
@@ -114,18 +114,18 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 			pchFile     [c-string!]            ;const char *
 			pvData      [byte-ptr!]            ;const void *
 			cubData     [integer!]             ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileReadAsync: "SteamAPI_ISteamRemoteStorage_FileReadAsync" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
 			pchFile     [c-string!]            ;const char *
 			nOffset     [integer!]             ;uint32
 			cubToRead   [integer!]             ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileReadAsyncComplete: "SteamAPI_ISteamRemoteStorage_FileReadAsyncComplete" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			hReadCall   [uint64! value]        ;SteamAPICall_t
+			hReadCall   [uint64-value!]        ;SteamAPICall_t
 			pvBuffer    [byte-ptr!]             ;void *
 			cubToRead   [integer!]             ;uint32
 			return: [logic!]
@@ -143,7 +143,7 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		SteamAPI_ISteamRemoteStorage_FileShare: "SteamAPI_ISteamRemoteStorage_FileShare" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
 			pchFile     [c-string!]            ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_SetSyncPlatforms: "SteamAPI_ISteamRemoteStorage_SetSyncPlatforms" [
 			instancePtr         [ISteamRemoteStorage!];intptr_t
@@ -154,23 +154,23 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		SteamAPI_ISteamRemoteStorage_FileWriteStreamOpen: "SteamAPI_ISteamRemoteStorage_FileWriteStreamOpen" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
 			pchFile     [c-string!]            ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileWriteStreamWriteChunk: {SteamAPI_ISteamRemoteStorage_FileWriteStreamWriteChunk} [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			writeHandle [uint64! value]        ;UGCFileWriteStreamHandle_t
+			writeHandle [uint64-value!]        ;UGCFileWriteStreamHandle_t
 			pvData      [byte-ptr!]            ;const void *
 			cubData     [integer!]             ;int32
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileWriteStreamClose: "SteamAPI_ISteamRemoteStorage_FileWriteStreamClose" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			writeHandle [uint64! value]        ;UGCFileWriteStreamHandle_t
+			writeHandle [uint64-value!]        ;UGCFileWriteStreamHandle_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileWriteStreamCancel: "SteamAPI_ISteamRemoteStorage_FileWriteStreamCancel" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			writeHandle [uint64! value]        ;UGCFileWriteStreamHandle_t
+			writeHandle [uint64-value!]        ;UGCFileWriteStreamHandle_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_FileExists: "SteamAPI_ISteamRemoteStorage_FileExists" [
@@ -191,7 +191,7 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		SteamAPI_ISteamRemoteStorage_GetFileTimestamp: "SteamAPI_ISteamRemoteStorage_GetFileTimestamp" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
 			pchFile     [c-string!]            ;const char *
-			return: [int64!]
+			return: [int64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetSyncPlatforms: "SteamAPI_ISteamRemoteStorage_GetSyncPlatforms" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
@@ -210,8 +210,8 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		]
 		SteamAPI_ISteamRemoteStorage_GetQuota: "SteamAPI_ISteamRemoteStorage_GetQuota" [
 			instancePtr      [ISteamRemoteStorage!];intptr_t
-			pnTotalBytes     [uint64-ref!]     ;uint64 *
-			puAvailableBytes [uint64-ref!]     ;uint64 *
+			pnTotalBytes     [uint64-ptr!]     ;uint64 *
+			puAvailableBytes [uint64-ptr!]     ;uint64 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_IsCloudEnabledForAccount: {SteamAPI_ISteamRemoteStorage_IsCloudEnabledForAccount} [
@@ -228,29 +228,29 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		]
 		SteamAPI_ISteamRemoteStorage_UGCDownload: "SteamAPI_ISteamRemoteStorage_UGCDownload" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			hContent    [uint64! value]        ;UGCHandle_t
+			hContent    [uint64-value!]        ;UGCHandle_t
 			unPriority  [integer!]             ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetUGCDownloadProgress: {SteamAPI_ISteamRemoteStorage_GetUGCDownloadProgress} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			hContent          [uint64! value]  ;UGCHandle_t
+			hContent          [uint64-value!]  ;UGCHandle_t
 			pnBytesDownloaded [int-ptr!]       ;int32 *
 			pnBytesExpected   [int-ptr!]       ;int32 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetUGCDetails: "SteamAPI_ISteamRemoteStorage_GetUGCDetails" [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			hContent          [uint64! value]  ;UGCHandle_t
+			hContent          [uint64-value!]  ;UGCHandle_t
 			pnAppID           [int-ptr!]       ;AppId_t *
-			ppchName          [string-ref!]    ;char **
+			ppchName          [string-ptr!]    ;char **
 			pnFileSizeInBytes [int-ptr!]       ;int32 *
-			pSteamIDOwner     [CSteamID-ref!]  ;class CSteamID *
+			pSteamIDOwner     [CSteamID-ptr!]  ;class CSteamID *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UGCRead: "SteamAPI_ISteamRemoteStorage_UGCRead" [
 			instancePtr   [ISteamRemoteStorage!];intptr_t
-			hContent      [uint64! value]      ;UGCHandle_t
+			hContent      [uint64-value!]      ;UGCHandle_t
 			pvData        [byte-ptr!]          ;void *
 			cubDataToRead [integer!]           ;int32
 			cOffset       [integer!]           ;uint32
@@ -264,7 +264,7 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 		SteamAPI_ISteamRemoteStorage_GetCachedUGCHandle: "SteamAPI_ISteamRemoteStorage_GetCachedUGCHandle" [
 			instancePtr    [ISteamRemoteStorage!];intptr_t
 			iCachedContent [integer!]          ;int32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_PublishWorkshopFile: "SteamAPI_ISteamRemoteStorage_PublishWorkshopFile" [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
@@ -276,106 +276,106 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 			eVisibility       [ERemoteStoragePublishedFileVisibility!];ERemoteStoragePublishedFileVisibility
 			pTags             [int-ptr!]       ;struct SteamParamStringArray_t *
 			eWorkshopFileType [EWorkshopFileType!];EWorkshopFileType
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_CreatePublishedFileUpdateRequest: {SteamAPI_ISteamRemoteStorage_CreatePublishedFileUpdateRequest} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileFile: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileFile} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
-			updateHandle [uint64! value]       ;PublishedFileUpdateHandle_t
+			updateHandle [uint64-value!]       ;PublishedFileUpdateHandle_t
 			pchFile      [c-string!]           ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFilePreviewFile: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFilePreviewFile} [
 			instancePtr    [ISteamRemoteStorage!];intptr_t
-			updateHandle   [uint64! value]     ;PublishedFileUpdateHandle_t
+			updateHandle   [uint64-value!]     ;PublishedFileUpdateHandle_t
 			pchPreviewFile [c-string!]         ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTitle: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTitle} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
-			updateHandle [uint64! value]       ;PublishedFileUpdateHandle_t
+			updateHandle [uint64-value!]       ;PublishedFileUpdateHandle_t
 			pchTitle     [c-string!]           ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileDescription: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileDescription} [
 			instancePtr    [ISteamRemoteStorage!];intptr_t
-			updateHandle   [uint64! value]     ;PublishedFileUpdateHandle_t
+			updateHandle   [uint64-value!]     ;PublishedFileUpdateHandle_t
 			pchDescription [c-string!]         ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileVisibility: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileVisibility} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
-			updateHandle [uint64! value]       ;PublishedFileUpdateHandle_t
+			updateHandle [uint64-value!]       ;PublishedFileUpdateHandle_t
 			eVisibility  [ERemoteStoragePublishedFileVisibility!];ERemoteStoragePublishedFileVisibility
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTags: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileTags} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
-			updateHandle [uint64! value]       ;PublishedFileUpdateHandle_t
+			updateHandle [uint64-value!]       ;PublishedFileUpdateHandle_t
 			pTags        [int-ptr!]            ;struct SteamParamStringArray_t *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_CommitPublishedFileUpdate: {SteamAPI_ISteamRemoteStorage_CommitPublishedFileUpdate} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
-			updateHandle [uint64! value]       ;PublishedFileUpdateHandle_t
-			return: [uint64! value]
+			updateHandle [uint64-value!]       ;PublishedFileUpdateHandle_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetPublishedFileDetails: {SteamAPI_ISteamRemoteStorage_GetPublishedFileDetails} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
 			unMaxSecondsOld   [integer!]       ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_DeletePublishedFile: "SteamAPI_ISteamRemoteStorage_DeletePublishedFile" [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_EnumerateUserPublishedFiles: {SteamAPI_ISteamRemoteStorage_EnumerateUserPublishedFiles} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
 			unStartIndex [integer!]            ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_SubscribePublishedFile: {SteamAPI_ISteamRemoteStorage_SubscribePublishedFile} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_EnumerateUserSubscribedFiles: {SteamAPI_ISteamRemoteStorage_EnumerateUserSubscribedFiles} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
 			unStartIndex [integer!]            ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_UnsubscribePublishedFile: {SteamAPI_ISteamRemoteStorage_UnsubscribePublishedFile} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdatePublishedFileSetChangeDescription: {SteamAPI_ISteamRemoteStorage_UpdatePublishedFileSetChangeDescription} [
 			instancePtr         [ISteamRemoteStorage!];intptr_t
-			updateHandle        [uint64! value];PublishedFileUpdateHandle_t
+			updateHandle        [uint64-value!];PublishedFileUpdateHandle_t
 			pchChangeDescription[c-string!]    ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetPublishedItemVoteDetails: {SteamAPI_ISteamRemoteStorage_GetPublishedItemVoteDetails} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_UpdateUserPublishedItemVote: {SteamAPI_ISteamRemoteStorage_UpdateUserPublishedItemVote} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
 			bVoteUp           [logic!]         ;bool
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_GetUserPublishedItemVoteDetails: {SteamAPI_ISteamRemoteStorage_GetUserPublishedItemVoteDetails} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
-			return: [uint64! value]
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_EnumerateUserSharedWorkshopFiles: {SteamAPI_ISteamRemoteStorage_EnumerateUserSharedWorkshopFiles} [
 			instancePtr   [ISteamRemoteStorage!];intptr_t
@@ -383,7 +383,7 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 			unStartIndex  [integer!]           ;uint32
 			pRequiredTags [int-ptr!]           ;struct SteamParamStringArray_t *
 			pExcludedTags [int-ptr!]           ;struct SteamParamStringArray_t *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_PublishVideo: "SteamAPI_ISteamRemoteStorage_PublishVideo" [
 			instancePtr        [ISteamRemoteStorage!];intptr_t
@@ -396,19 +396,19 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 			pchDescription     [c-string!]     ;const char *
 			eVisibility        [ERemoteStoragePublishedFileVisibility!];ERemoteStoragePublishedFileVisibility
 			pTags              [int-ptr!]      ;struct SteamParamStringArray_t *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_SetUserPublishedFileAction: {SteamAPI_ISteamRemoteStorage_SetUserPublishedFileAction} [
 			instancePtr       [ISteamRemoteStorage!];intptr_t
-			unPublishedFileId [uint64! value]  ;PublishedFileId_t
+			unPublishedFileId [uint64-value!]  ;PublishedFileId_t
 			eAction           [EWorkshopFileAction!];EWorkshopFileAction
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_EnumeratePublishedFilesByUserAction: {SteamAPI_ISteamRemoteStorage_EnumeratePublishedFilesByUserAction} [
 			instancePtr  [ISteamRemoteStorage!];intptr_t
 			eAction      [EWorkshopFileAction!];EWorkshopFileAction
 			unStartIndex [integer!]            ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_EnumeratePublishedWorkshopFiles: {SteamAPI_ISteamRemoteStorage_EnumeratePublishedWorkshopFiles} [
 			instancePtr      [ISteamRemoteStorage!];intptr_t
@@ -418,14 +418,14 @@ ISteamRemoteStorage: declare ISteamRemoteStorage!
 			unDays           [integer!]        ;uint32
 			pTags            [int-ptr!]        ;struct SteamParamStringArray_t *
 			pUserTags        [int-ptr!]        ;struct SteamParamStringArray_t *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamRemoteStorage_UGCDownloadToLocation: "SteamAPI_ISteamRemoteStorage_UGCDownloadToLocation" [
 			instancePtr [ISteamRemoteStorage!] ;intptr_t
-			hContent    [uint64! value]        ;UGCHandle_t
+			hContent    [uint64-value!]        ;UGCHandle_t
 			pchLocation [c-string!]            ;const char *
 			unPriority  [integer!]             ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-Screenshots.reds
+++ b/Library/Steam/SteamAPI/Steam-Screenshots.reds
@@ -69,7 +69,7 @@ ISteamScreenshots: declare ISteamScreenshots!
 		SteamAPI_ISteamScreenshots_TagPublishedFile: "SteamAPI_ISteamScreenshots_TagPublishedFile" [
 			instancePtr       [ISteamScreenshots!];intptr_t
 			hScreenshot       [integer!]       ;ScreenshotHandle
-			unPublishedFileID [uint64! value]  ;PublishedFileId_t
+			unPublishedFileID [uint64-value!]  ;PublishedFileId_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamScreenshots_IsScreenshotsHooked: "SteamAPI_ISteamScreenshots_IsScreenshotsHooked" [

--- a/Library/Steam/SteamAPI/Steam-UGC.reds
+++ b/Library/Steam/SteamAPI/Steam-UGC.reds
@@ -171,7 +171,7 @@ ISteamUGC: declare ISteamUGC!
 			nCreatorAppID    [integer!]        ;AppId_t
 			nConsumerAppID   [integer!]        ;AppId_t
 			unPage           [integer!]        ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_CreateQueryAllUGCRequest: "SteamAPI_ISteamUGC_CreateQueryAllUGCRequest" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
@@ -180,29 +180,29 @@ ISteamUGC: declare ISteamUGC!
 			nCreatorAppID       [integer!]     ;AppId_t
 			nConsumerAppID      [integer!]     ;AppId_t
 			unPage              [integer!]     ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest: "SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			pvecPublishedFileID [uint64-ref!]  ;PublishedFileId_t *
+			pvecPublishedFileID [uint64-ptr!]  ;PublishedFileId_t *
 			unNumPublishedFileIDs[integer!]    ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_SendQueryUGCRequest: "SteamAPI_ISteamUGC_SendQueryUGCRequest" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
-			return: [uint64! value]
+			handle      [uint64-value!]        ;UGCQueryHandle_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCResult: "SteamAPI_ISteamUGC_GetQueryUGCResult" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			index       [integer!]             ;uint32
 			pDetails    [int-ptr!]             ;struct SteamUGCDetails_t *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCPreviewURL: "SteamAPI_ISteamUGC_GetQueryUGCPreviewURL" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			index       [integer!]             ;uint32
 			pchURL      [c-string!]            ;char *
 			cchURLSize  [integer!]             ;uint32
@@ -210,7 +210,7 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCMetadata: "SteamAPI_ISteamUGC_GetQueryUGCMetadata" [
 			instancePtr     [ISteamUGC!]       ;intptr_t
-			handle          [uint64! value]    ;UGCQueryHandle_t
+			handle          [uint64-value!]    ;UGCQueryHandle_t
 			index           [integer!]         ;uint32
 			pchMetadata     [c-string!]        ;char *
 			cchMetadatasize [integer!]         ;uint32
@@ -218,29 +218,29 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCChildren: "SteamAPI_ISteamUGC_GetQueryUGCChildren" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			index               [integer!]     ;uint32
-			pvecPublishedFileID [uint64-ref!]  ;PublishedFileId_t *
+			pvecPublishedFileID [uint64-ptr!]  ;PublishedFileId_t *
 			cMaxEntries         [integer!]     ;uint32
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCStatistic: "SteamAPI_ISteamUGC_GetQueryUGCStatistic" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			index       [integer!]             ;uint32
 			eStatType   [EItemStatistic!]      ;EItemStatistic
-			pStatValue  [uint64-ref!]          ;uint64 *
+			pStatValue  [uint64-ptr!]          ;uint64 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCNumAdditionalPreviews: {SteamAPI_ISteamUGC_GetQueryUGCNumAdditionalPreviews} [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			index       [integer!]             ;uint32
 			return: [integer!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCAdditionalPreview: "SteamAPI_ISteamUGC_GetQueryUGCAdditionalPreview" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			index               [integer!]     ;uint32
 			previewIndex        [integer!]     ;uint32
 			pchURLOrVideoID     [c-string!]    ;char *
@@ -252,13 +252,13 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCNumKeyValueTags: "SteamAPI_ISteamUGC_GetQueryUGCNumKeyValueTags" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			index       [integer!]             ;uint32
 			return: [integer!]
 		]
 		SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag: "SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			handle           [uint64! value]   ;UGCQueryHandle_t
+			handle           [uint64-value!]   ;UGCQueryHandle_t
 			index            [integer!]        ;uint32
 			keyValueTagIndex [integer!]        ;uint32
 			pchKey           [c-string!]       ;char *
@@ -269,263 +269,263 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_ReleaseQueryUGCRequest: "SteamAPI_ISteamUGC_ReleaseQueryUGCRequest" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddRequiredTag: "SteamAPI_ISteamUGC_AddRequiredTag" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			pTagName    [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddExcludedTag: "SteamAPI_ISteamUGC_AddExcludedTag" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			pTagName    [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnOnlyIDs: "SteamAPI_ISteamUGC_SetReturnOnlyIDs" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
-			handle         [uint64! value]     ;UGCQueryHandle_t
+			handle         [uint64-value!]     ;UGCQueryHandle_t
 			bReturnOnlyIDs [logic!]            ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnKeyValueTags: "SteamAPI_ISteamUGC_SetReturnKeyValueTags" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			bReturnKeyValueTags [logic!]       ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnLongDescription: "SteamAPI_ISteamUGC_SetReturnLongDescription" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			bReturnLongDescription[logic!]     ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnMetadata: "SteamAPI_ISteamUGC_SetReturnMetadata" [
 			instancePtr     [ISteamUGC!]       ;intptr_t
-			handle          [uint64! value]    ;UGCQueryHandle_t
+			handle          [uint64-value!]    ;UGCQueryHandle_t
 			bReturnMetadata [logic!]           ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnChildren: "SteamAPI_ISteamUGC_SetReturnChildren" [
 			instancePtr     [ISteamUGC!]       ;intptr_t
-			handle          [uint64! value]    ;UGCQueryHandle_t
+			handle          [uint64-value!]    ;UGCQueryHandle_t
 			bReturnChildren [logic!]           ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnAdditionalPreviews: "SteamAPI_ISteamUGC_SetReturnAdditionalPreviews" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			bReturnAdditionalPreviews[logic!]  ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetReturnTotalOnly: "SteamAPI_ISteamUGC_SetReturnTotalOnly" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			handle           [uint64! value]   ;UGCQueryHandle_t
+			handle           [uint64-value!]   ;UGCQueryHandle_t
 			bReturnTotalOnly [logic!]          ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetLanguage: "SteamAPI_ISteamUGC_SetLanguage" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			pchLanguage [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetAllowCachedResponse: "SteamAPI_ISteamUGC_SetAllowCachedResponse" [
 			instancePtr     [ISteamUGC!]       ;intptr_t
-			handle          [uint64! value]    ;UGCQueryHandle_t
+			handle          [uint64-value!]    ;UGCQueryHandle_t
 			unMaxAgeSeconds [integer!]         ;uint32
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetCloudFileNameFilter: "SteamAPI_ISteamUGC_SetCloudFileNameFilter" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			handle              [uint64! value];UGCQueryHandle_t
+			handle              [uint64-value!];UGCQueryHandle_t
 			pMatchCloudFileName [c-string!]    ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetMatchAnyTag: "SteamAPI_ISteamUGC_SetMatchAnyTag" [
 			instancePtr  [ISteamUGC!]          ;intptr_t
-			handle       [uint64! value]       ;UGCQueryHandle_t
+			handle       [uint64-value!]       ;UGCQueryHandle_t
 			bMatchAnyTag [logic!]              ;bool
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetSearchText: "SteamAPI_ISteamUGC_SetSearchText" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			pSearchText [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetRankedByTrendDays: "SteamAPI_ISteamUGC_SetRankedByTrendDays" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			unDays      [integer!]             ;uint32
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddRequiredKeyValueTag: "SteamAPI_ISteamUGC_AddRequiredKeyValueTag" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCQueryHandle_t
+			handle      [uint64-value!]        ;UGCQueryHandle_t
 			pKey        [c-string!]            ;const char *
 			pValue      [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_RequestUGCDetails: "SteamAPI_ISteamUGC_RequestUGCDetails" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
 			unMaxAgeSeconds  [integer!]        ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_CreateItem: "SteamAPI_ISteamUGC_CreateItem" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
 			nConsumerAppId [integer!]          ;AppId_t
 			eFileType      [EWorkshopFileType!];EWorkshopFileType
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_StartItemUpdate: "SteamAPI_ISteamUGC_StartItemUpdate" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
 			nConsumerAppId   [integer!]        ;AppId_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_SetItemTitle: "SteamAPI_ISteamUGC_SetItemTitle" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pchTitle    [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemDescription: "SteamAPI_ISteamUGC_SetItemDescription" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
-			handle         [uint64! value]     ;UGCUpdateHandle_t
+			handle         [uint64-value!]     ;UGCUpdateHandle_t
 			pchDescription [c-string!]         ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemUpdateLanguage: "SteamAPI_ISteamUGC_SetItemUpdateLanguage" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pchLanguage [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemMetadata: "SteamAPI_ISteamUGC_SetItemMetadata" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pchMetaData [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemVisibility: "SteamAPI_ISteamUGC_SetItemVisibility" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			eVisibility [ERemoteStoragePublishedFileVisibility!];ERemoteStoragePublishedFileVisibility
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemTags: "SteamAPI_ISteamUGC_SetItemTags" [
 			instancePtr  [ISteamUGC!]          ;intptr_t
-			updateHandle [uint64! value]       ;UGCUpdateHandle_t
+			updateHandle [uint64-value!]       ;UGCUpdateHandle_t
 			pTags        [int-ptr!]            ;const struct SteamParamStringArray_t *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemContent: "SteamAPI_ISteamUGC_SetItemContent" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			handle           [uint64! value]   ;UGCUpdateHandle_t
+			handle           [uint64-value!]   ;UGCUpdateHandle_t
 			pszContentFolder [c-string!]       ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SetItemPreview: "SteamAPI_ISteamUGC_SetItemPreview" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
-			handle         [uint64! value]     ;UGCUpdateHandle_t
+			handle         [uint64-value!]     ;UGCUpdateHandle_t
 			pszPreviewFile [c-string!]         ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_RemoveItemKeyValueTags: "SteamAPI_ISteamUGC_RemoveItemKeyValueTags" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pchKey      [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddItemKeyValueTag: "SteamAPI_ISteamUGC_AddItemKeyValueTag" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pchKey      [c-string!]            ;const char *
 			pchValue    [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddItemPreviewFile: "SteamAPI_ISteamUGC_AddItemPreviewFile" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
-			handle         [uint64! value]     ;UGCUpdateHandle_t
+			handle         [uint64-value!]     ;UGCUpdateHandle_t
 			pszPreviewFile [c-string!]         ;const char *
 			type           [EItemPreviewType!] ;EItemPreviewType
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_AddItemPreviewVideo: "SteamAPI_ISteamUGC_AddItemPreviewVideo" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			pszVideoID  [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_UpdateItemPreviewFile: "SteamAPI_ISteamUGC_UpdateItemPreviewFile" [
 			instancePtr    [ISteamUGC!]        ;intptr_t
-			handle         [uint64! value]     ;UGCUpdateHandle_t
+			handle         [uint64-value!]     ;UGCUpdateHandle_t
 			index          [integer!]          ;uint32
 			pszPreviewFile [c-string!]         ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_UpdateItemPreviewVideo: "SteamAPI_ISteamUGC_UpdateItemPreviewVideo" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			index       [integer!]             ;uint32
 			pszVideoID  [c-string!]            ;const char *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_RemoveItemPreview: "SteamAPI_ISteamUGC_RemoveItemPreview" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			handle      [uint64! value]        ;UGCUpdateHandle_t
+			handle      [uint64-value!]        ;UGCUpdateHandle_t
 			index       [integer!]             ;uint32
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_SubmitItemUpdate: "SteamAPI_ISteamUGC_SubmitItemUpdate" [
 			instancePtr   [ISteamUGC!]         ;intptr_t
-			handle        [uint64! value]      ;UGCUpdateHandle_t
+			handle        [uint64-value!]      ;UGCUpdateHandle_t
 			pchChangeNote [c-string!]          ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_GetItemUpdateProgress: "SteamAPI_ISteamUGC_GetItemUpdateProgress" [
 			instancePtr       [ISteamUGC!]     ;intptr_t
-			handle            [uint64! value]  ;UGCUpdateHandle_t
-			punBytesProcessed [uint64-ref!]    ;uint64 *
-			punBytesTotal     [uint64-ref!]    ;uint64 *
+			handle            [uint64-value!]  ;UGCUpdateHandle_t
+			punBytesProcessed [uint64-ptr!]    ;uint64 *
+			punBytesTotal     [uint64-ptr!]    ;uint64 *
 			return: [EItemUpdateStatus!]
 		]
 		SteamAPI_ISteamUGC_SetUserItemVote: "SteamAPI_ISteamUGC_SetUserItemVote" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
 			bVoteUp          [logic!]          ;bool
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_GetUserItemVote: "SteamAPI_ISteamUGC_GetUserItemVote" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_AddItemToFavorites: "SteamAPI_ISteamUGC_AddItemToFavorites" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
 			nAppId           [integer!]        ;AppId_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_RemoveItemFromFavorites: "SteamAPI_ISteamUGC_RemoveItemFromFavorites" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
 			nAppId           [integer!]        ;AppId_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_SubscribeItem: "SteamAPI_ISteamUGC_SubscribeItem" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_UnsubscribeItem: "SteamAPI_ISteamUGC_UnsubscribeItem" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			return: [uint64! value]
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_GetNumSubscribedItems: "SteamAPI_ISteamUGC_GetNumSubscribedItems" [
 			instancePtr [ISteamUGC!]           ;intptr_t
@@ -533,19 +533,19 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_GetSubscribedItems: "SteamAPI_ISteamUGC_GetSubscribedItems" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			pvecPublishedFileID [uint64-ref!]  ;PublishedFileId_t *
+			pvecPublishedFileID [uint64-ptr!]  ;PublishedFileId_t *
 			cMaxEntries         [integer!]     ;uint32
 			return: [integer!]
 		]
 		SteamAPI_ISteamUGC_GetItemState: "SteamAPI_ISteamUGC_GetItemState" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
 			return: [integer!]
 		]
 		SteamAPI_ISteamUGC_GetItemInstallInfo: "SteamAPI_ISteamUGC_GetItemInstallInfo" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
-			punSizeOnDisk    [uint64-ref!]     ;uint64 *
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
+			punSizeOnDisk    [uint64-ptr!]     ;uint64 *
 			pchFolder        [c-string!]       ;char *
 			cchFolderSize    [integer!]        ;uint32
 			punTimeStamp     [int-ptr!]        ;uint32 *
@@ -553,14 +553,14 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_GetItemDownloadInfo: "SteamAPI_ISteamUGC_GetItemDownloadInfo" [
 			instancePtr        [ISteamUGC!]    ;intptr_t
-			nPublishedFileID   [uint64! value] ;PublishedFileId_t
-			punBytesDownloaded [uint64-ref!]   ;uint64 *
-			punBytesTotal      [uint64-ref!]   ;uint64 *
+			nPublishedFileID   [uint64-value!] ;PublishedFileId_t
+			punBytesDownloaded [uint64-ptr!]   ;uint64 *
+			punBytesTotal      [uint64-ptr!]   ;uint64 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUGC_DownloadItem: "SteamAPI_ISteamUGC_DownloadItem" [
 			instancePtr      [ISteamUGC!]      ;intptr_t
-			nPublishedFileID [uint64! value]   ;PublishedFileId_t
+			nPublishedFileID [uint64-value!]   ;PublishedFileId_t
 			bHighPriority    [logic!]          ;bool
 			return: [logic!]
 		]
@@ -576,19 +576,19 @@ ISteamUGC: declare ISteamUGC!
 		]
 		SteamAPI_ISteamUGC_StartPlaytimeTracking: "SteamAPI_ISteamUGC_StartPlaytimeTracking" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			pvecPublishedFileID [uint64-ref!]  ;PublishedFileId_t *
+			pvecPublishedFileID [uint64-ptr!]  ;PublishedFileId_t *
 			unNumPublishedFileIDs[integer!]    ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_StopPlaytimeTracking: "SteamAPI_ISteamUGC_StopPlaytimeTracking" [
 			instancePtr         [ISteamUGC!]   ;intptr_t
-			pvecPublishedFileID [uint64-ref!]  ;PublishedFileId_t *
+			pvecPublishedFileID [uint64-ptr!]  ;PublishedFileId_t *
 			unNumPublishedFileIDs[integer!]    ;uint32
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUGC_StopPlaytimeTrackingForAllItems: "SteamAPI_ISteamUGC_StopPlaytimeTrackingForAllItems" [
 			instancePtr [ISteamUGC!]           ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 	]
 ]

--- a/Library/Steam/SteamAPI/Steam-UnifiedMessages.reds
+++ b/Library/Steam/SteamAPI/Steam-UnifiedMessages.reds
@@ -15,19 +15,19 @@ ISteamUnifiedMessages: declare ISteamUnifiedMessages!
 			pchServiceMethod    [c-string!]    ;const char *
 			pRequestBuffer      [byte-ptr!]    ;const void *
 			unRequestBufferSize [integer!]     ;uint32
-			unContext           [uint64! value];uint64
-			return: [uint64! value]
+			unContext           [uint64-value!];uint64
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUnifiedMessages_GetMethodResponseInfo: {SteamAPI_ISteamUnifiedMessages_GetMethodResponseInfo} [
 			instancePtr     [ISteamUnifiedMessages!];intptr_t
-			hHandle         [uint64! value]    ;ClientUnifiedMessageHandle
+			hHandle         [uint64-value!]    ;ClientUnifiedMessageHandle
 			punResponseSize [int-ptr!]         ;uint32 *
 			peResult        [int-ptr!]         ;EResult *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUnifiedMessages_GetMethodResponseData: {SteamAPI_ISteamUnifiedMessages_GetMethodResponseData} [
 			instancePtr         [ISteamUnifiedMessages!];intptr_t
-			hHandle             [uint64! value];ClientUnifiedMessageHandle
+			hHandle             [uint64-value!];ClientUnifiedMessageHandle
 			pResponseBuffer     [byte-ptr!]    ;void *
 			unResponseBufferSize[integer!]     ;uint32
 			bAutoRelease        [logic!]       ;bool
@@ -35,7 +35,7 @@ ISteamUnifiedMessages: declare ISteamUnifiedMessages!
 		]
 		SteamAPI_ISteamUnifiedMessages_ReleaseMethod: "SteamAPI_ISteamUnifiedMessages_ReleaseMethod" [
 			instancePtr [ISteamUnifiedMessages!];intptr_t
-			hHandle     [uint64! value]        ;ClientUnifiedMessageHandle
+			hHandle     [uint64-value!]        ;ClientUnifiedMessageHandle
 			return: [logic!]
 		]
 		SteamAPI_ISteamUnifiedMessages_SendNotification: "SteamAPI_ISteamUnifiedMessages_SendNotification" [

--- a/Library/Steam/SteamAPI/Steam-User.reds
+++ b/Library/Steam/SteamAPI/Steam-User.reds
@@ -20,7 +20,7 @@ ISteamUser: declare ISteamUser!
 		]
 		SteamAPI_ISteamUser_GetSteamID: "SteamAPI_ISteamUser_GetSteamID" [
 			instancePtr [ISteamUser!]          ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUser_InitiateGameConnection: "SteamAPI_ISteamUser_InitiateGameConnection" [
 			instancePtr       [ISteamUser!]    ;intptr_t
@@ -28,14 +28,14 @@ ISteamUser: declare ISteamUser!
 			cbMaxAuthBlob     [integer!]       ;int
 			steamIDGameServer [CSteamID!]      ;class CSteamID
 			unIPServer        [integer!]       ;uint32
-			usPortServer      [uint16!]        ;uint16
+			usPortServer      [uint16-value!]        ;uint16
 			bSecure           [logic!]         ;bool
 			return: [integer!]
 		]
 		SteamAPI_ISteamUser_TerminateGameConnection: "SteamAPI_ISteamUser_TerminateGameConnection" [
 			instancePtr  [ISteamUser!]         ;intptr_t
 			unIPServer   [integer!]            ;uint32
-			usPortServer [uint16!]             ;uint16
+			usPortServer [uint16-value!]             ;uint16
 		]
 		SteamAPI_ISteamUser_TrackAppUsageEvent: "SteamAPI_ISteamUser_TrackAppUsageEvent" [
 			instancePtr    [ISteamUser!]       ;intptr_t
@@ -125,13 +125,13 @@ ISteamUser: declare ISteamUser!
 			instancePtr       [ISteamUser!]    ;intptr_t
 			steamIDGameServer [CSteamID!]      ;class CSteamID
 			unIPServer        [integer!]       ;uint32
-			usPortServer      [uint16!]        ;uint16
+			usPortServer      [uint16-value!]        ;uint16
 		]
 		SteamAPI_ISteamUser_RequestEncryptedAppTicket: "SteamAPI_ISteamUser_RequestEncryptedAppTicket" [
 			instancePtr     [ISteamUser!]      ;intptr_t
 			pDataToInclude  [byte-ptr!]        ;void *
 			cbDataToInclude [integer!]         ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUser_GetEncryptedAppTicket: "SteamAPI_ISteamUser_GetEncryptedAppTicket" [
 			instancePtr [ISteamUser!]          ;intptr_t
@@ -153,7 +153,7 @@ ISteamUser: declare ISteamUser!
 		SteamAPI_ISteamUser_RequestStoreAuthURL: "SteamAPI_ISteamUser_RequestStoreAuthURL" [
 			instancePtr    [ISteamUser!]       ;intptr_t
 			pchRedirectURL [c-string!]         ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUser_BIsPhoneVerified: "SteamAPI_ISteamUser_BIsPhoneVerified" [
 			instancePtr [ISteamUser!]          ;intptr_t

--- a/Library/Steam/SteamAPI/Steam-UserStats.reds
+++ b/Library/Steam/SteamAPI/Steam-UserStats.reds
@@ -88,7 +88,7 @@ ISteamUserStats: declare ISteamUserStats!
 		SteamAPI_ISteamUserStats_GetAchievement: "SteamAPI_ISteamUserStats_GetAchievement" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
 			pchName     [c-string!]            ;const char *
-			pbAchieved  [logic-ref!]    ;bool *
+			pbAchieved  [logic-ptr!]    ;bool *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUserStats_SetAchievement: "SteamAPI_ISteamUserStats_SetAchievement" [
@@ -104,7 +104,7 @@ ISteamUserStats: declare ISteamUserStats!
 		SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime: {SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime} [
 			instancePtr   [ISteamUserStats!]   ;intptr_t
 			pchName       [c-string!]          ;const char *
-			pbAchieved    [logic-ref!]  ;bool *
+			pbAchieved    [logic-ptr!]  ;bool *
 			punUnlockTime [int-ptr!]           ;uint32 *
 			return: [logic!]
 		]
@@ -142,7 +142,7 @@ ISteamUserStats: declare ISteamUserStats!
 		SteamAPI_ISteamUserStats_RequestUserStats: "SteamAPI_ISteamUserStats_RequestUserStats" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
 			steamIDUser [CSteamID!]            ;class CSteamID
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetUserStat: "SteamAPI_ISteamUserStats_GetUserStat" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
@@ -162,14 +162,14 @@ ISteamUserStats: declare ISteamUserStats!
 			instancePtr [ISteamUserStats!]     ;intptr_t
 			steamIDUser [CSteamID!]            ;class CSteamID
 			pchName     [c-string!]            ;const char *
-			pbAchieved  [logic-ref!]    ;bool *
+			pbAchieved  [logic-ptr!]    ;bool *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUserStats_GetUserAchievementAndUnlockTime: {SteamAPI_ISteamUserStats_GetUserAchievementAndUnlockTime} [
 			instancePtr   [ISteamUserStats!]   ;intptr_t
 			steamIDUser   [CSteamID!]          ;class CSteamID
 			pchName       [c-string!]          ;const char *
-			pbAchieved    [logic-ref!]  ;bool *
+			pbAchieved    [logic-ptr!]  ;bool *
 			punUnlockTime [int-ptr!]           ;uint32 *
 			return: [logic!]
 		]
@@ -183,51 +183,51 @@ ISteamUserStats: declare ISteamUserStats!
 			pchLeaderboardName  [c-string!]    ;const char *
 			eLeaderboardSortMethod[ELeaderboardSortMethod!];ELeaderboardSortMethod
 			eLeaderboardDisplayType[ELeaderboardDisplayType!];ELeaderboardDisplayType
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_FindLeaderboard: "SteamAPI_ISteamUserStats_FindLeaderboard" [
 			instancePtr        [ISteamUserStats!];intptr_t
 			pchLeaderboardName [c-string!]     ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetLeaderboardName: "SteamAPI_ISteamUserStats_GetLeaderboardName" [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
 			return: [c-string!]
 		]
 		SteamAPI_ISteamUserStats_GetLeaderboardEntryCount: "SteamAPI_ISteamUserStats_GetLeaderboardEntryCount" [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
 			return: [integer!]
 		]
 		SteamAPI_ISteamUserStats_GetLeaderboardSortMethod: "SteamAPI_ISteamUserStats_GetLeaderboardSortMethod" [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
 			return: [ELeaderboardSortMethod!]
 		]
 		SteamAPI_ISteamUserStats_GetLeaderboardDisplayType: "SteamAPI_ISteamUserStats_GetLeaderboardDisplayType" [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
 			return: [ELeaderboardDisplayType!]
 		]
 		SteamAPI_ISteamUserStats_DownloadLeaderboardEntries: {SteamAPI_ISteamUserStats_DownloadLeaderboardEntries} [
 			instancePtr         [ISteamUserStats!];intptr_t
-			hSteamLeaderboard   [uint64! value];SteamLeaderboard_t
+			hSteamLeaderboard   [uint64-value!];SteamLeaderboard_t
 			eLeaderboardDataRequest[ELeaderboardDataRequest!];ELeaderboardDataRequest
 			nRangeStart         [integer!]     ;int
 			nRangeEnd           [integer!]     ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_DownloadLeaderboardEntriesForUsers: {SteamAPI_ISteamUserStats_DownloadLeaderboardEntriesForUsers} [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
-			prgUsers          [CSteamID-ref!]  ;class CSteamID *
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
+			prgUsers          [CSteamID-ptr!]  ;class CSteamID *
 			cUsers            [integer!]       ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry: {SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry} [
 			instancePtr         [ISteamUserStats!];intptr_t
-			hSteamLeaderboardEntries[uint64! value];SteamLeaderboardEntries_t
+			hSteamLeaderboardEntries[uint64-value!];SteamLeaderboardEntries_t
 			index               [integer!]     ;int
 			pLeaderboardEntry   [LeaderboardEntry!];struct LeaderboardEntry_t *
 			pDetails            [int-ptr!]     ;int32 *
@@ -236,33 +236,33 @@ ISteamUserStats: declare ISteamUserStats!
 		]
 		SteamAPI_ISteamUserStats_UploadLeaderboardScore: "SteamAPI_ISteamUserStats_UploadLeaderboardScore" [
 			instancePtr         [ISteamUserStats!];intptr_t
-			hSteamLeaderboard   [uint64! value];SteamLeaderboard_t
+			hSteamLeaderboard   [uint64-value!];SteamLeaderboard_t
 			eLeaderboardUploadScoreMethod[ELeaderboardUploadScoreMethod!];ELeaderboardUploadScoreMethod
 			nScore              [integer!]     ;int32
 			pScoreDetails       [int-ptr!]     ;const int32 *
 			cScoreDetailsCount  [integer!]     ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_AttachLeaderboardUGC: "SteamAPI_ISteamUserStats_AttachLeaderboardUGC" [
 			instancePtr       [ISteamUserStats!];intptr_t
-			hSteamLeaderboard [uint64! value]  ;SteamLeaderboard_t
-			hUGC              [uint64! value]  ;UGCHandle_t
-			return: [uint64! value]
+			hSteamLeaderboard [uint64-value!]  ;SteamLeaderboard_t
+			hUGC              [uint64-value!]  ;UGCHandle_t
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetNumberOfCurrentPlayers: "SteamAPI_ISteamUserStats_GetNumberOfCurrentPlayers" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages: {SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages} [
 			instancePtr [ISteamUserStats!]     ;intptr_t
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetMostAchievedAchievementInfo: {SteamAPI_ISteamUserStats_GetMostAchievedAchievementInfo} [
 			instancePtr  [ISteamUserStats!]    ;intptr_t
 			pchName      [c-string!]           ;char *
 			unNameBufLen [integer!]            ;uint32
 			pflPercent   [pointer! [float32!]] ;float *
-			pbAchieved   [logic-ref!]   ;bool *
+			pbAchieved   [logic-ptr!]   ;bool *
 			return: [integer!]
 		]
 		SteamAPI_ISteamUserStats_GetNextMostAchievedAchievementInfo: {SteamAPI_ISteamUserStats_GetNextMostAchievedAchievementInfo} [
@@ -271,7 +271,7 @@ ISteamUserStats: declare ISteamUserStats!
 			pchName           [c-string!]      ;char *
 			unNameBufLen      [integer!]       ;uint32
 			pflPercent        [pointer! [float32!]];float *
-			pbAchieved        [logic-ref!];bool *
+			pbAchieved        [logic-ptr!];bool *
 			return: [integer!]
 		]
 		SteamAPI_ISteamUserStats_GetAchievementAchievedPercent: {SteamAPI_ISteamUserStats_GetAchievementAchievedPercent} [
@@ -283,12 +283,12 @@ ISteamUserStats: declare ISteamUserStats!
 		SteamAPI_ISteamUserStats_RequestGlobalStats: "SteamAPI_ISteamUserStats_RequestGlobalStats" [
 			instancePtr  [ISteamUserStats!]    ;intptr_t
 			nHistoryDays [integer!]            ;int
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUserStats_GetGlobalStat: "SteamAPI_ISteamUserStats_GetGlobalStat" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
 			pchStatName [c-string!]            ;const char *
-			pData       [int64-ref!]    ;int64 *
+			pData       [int64-ptr!]    ;int64 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUserStats_GetGlobalStat0: "SteamAPI_ISteamUserStats_GetGlobalStat0" [
@@ -300,7 +300,7 @@ ISteamUserStats: declare ISteamUserStats!
 		SteamAPI_ISteamUserStats_GetGlobalStatHistory: "SteamAPI_ISteamUserStats_GetGlobalStatHistory" [
 			instancePtr [ISteamUserStats!]     ;intptr_t
 			pchStatName [c-string!]            ;const char *
-			pData       [int64-ref!]    ;int64 *
+			pData       [int64-ptr!]    ;int64 *
 			cubData     [integer!]             ;uint32
 			return: [integer!]
 		]

--- a/Library/Steam/SteamAPI/Steam-Utils.reds
+++ b/Library/Steam/SteamAPI/Steam-Utils.reds
@@ -70,7 +70,7 @@ ISteamUtils: declare ISteamUtils!
 		SteamAPI_ISteamUtils_GetCSERIPPort: "SteamAPI_ISteamUtils_GetCSERIPPort" [
 			instancePtr [ISteamUtils!]         ;intptr_t
 			unIP        [int-ptr!]             ;uint32 *
-			usPort      [pointer! [uint16!]]   ;uint16 *
+			usPort      [uint16-ptr!]   ;uint16 *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUtils_GetCurrentBatteryPower: "SteamAPI_ISteamUtils_GetCurrentBatteryPower" [
@@ -87,22 +87,22 @@ ISteamUtils: declare ISteamUtils!
 		]
 		SteamAPI_ISteamUtils_IsAPICallCompleted: "SteamAPI_ISteamUtils_IsAPICallCompleted" [
 			instancePtr   [ISteamUtils!]       ;intptr_t
-			hSteamAPICall [uint64! value]      ;SteamAPICall_t
-			pbFailed      [logic-ref!]  ;bool *
+			hSteamAPICall [uint64-value!]      ;SteamAPICall_t
+			pbFailed      [logic-ptr!]  ;bool *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUtils_GetAPICallFailureReason: "SteamAPI_ISteamUtils_GetAPICallFailureReason" [
 			instancePtr   [ISteamUtils!]       ;intptr_t
-			hSteamAPICall [uint64! value]      ;SteamAPICall_t
+			hSteamAPICall [uint64-value!]      ;SteamAPICall_t
 			return: [ESteamAPICallFailure!]
 		]
 		SteamAPI_ISteamUtils_GetAPICallResult: "SteamAPI_ISteamUtils_GetAPICallResult" [
 			instancePtr       [ISteamUtils!]   ;intptr_t
-			hSteamAPICall     [uint64! value]  ;SteamAPICall_t
+			hSteamAPICall     [uint64-value!]  ;SteamAPICall_t
 			pCallback         [byte-ptr!]      ;void *
 			cubCallback       [integer!]       ;int
 			iCallbackExpected [integer!]       ;int
-			pbFailed          [logic-ref!];bool *
+			pbFailed          [logic-ptr!];bool *
 			return: [logic!]
 		]
 		SteamAPI_ISteamUtils_GetIPCCallCount: "SteamAPI_ISteamUtils_GetIPCCallCount" [
@@ -124,7 +124,7 @@ ISteamUtils: declare ISteamUtils!
 		SteamAPI_ISteamUtils_CheckFileSignature: "SteamAPI_ISteamUtils_CheckFileSignature" [
 			instancePtr [ISteamUtils!]         ;intptr_t
 			szFileName  [c-string!]            ;const char *
-			return: [uint64! value]
+			return: [uint64-value!]
 		]
 		SteamAPI_ISteamUtils_ShowGamepadTextInput: "SteamAPI_ISteamUtils_ShowGamepadTextInput" [
 			instancePtr     [ISteamUtils!]     ;intptr_t

--- a/Library/Vorbis/examples/vorbis-decoder.reds
+++ b/Library/Vorbis/examples/vorbis-decoder.reds
@@ -195,11 +195,6 @@ vorbis-decoder: context [
                                     if 0 = result [ ;test for success!
                                         vorbis_synthesis_blockin vd vb
 
-                                        ;pcm is a multichannel float vector.  In stereo, for
-                                        ;example, pcm[0] is left, and pcm[1] is right.  samples is
-                                        ;the size of each channel.  Convert the float values
-                                        ;(-1.<=range<=1.) to whatever PCM format and write it out
-
                                         pcm: 0
                                         while [ 
                                             samples: vorbis_synthesis_pcmout vd :pcm

--- a/Library/Vorbis/vorbis.reds
+++ b/Library/Vorbis/vorbis.reds
@@ -15,7 +15,7 @@ Red/System [
 	#default  [ #define VORBIS_LIBRARY "libvorbis.so" ] ;@@ not tested!
 ]
 
-float32-ptr-ref!: alias struct! [value [float32-ptr!]]
+#include %../os/definitions.reds ;common aliases and defines
 
 ;-- Vorbis ERRORS and return codes --
 
@@ -73,8 +73,8 @@ vorbis_dsp_state!: alias struct! [
     analysisp [integer!]
     vi        [vorbis_info!]
 
-    pcm            [float32-ptr-ref!]
-    pcmret         [float32-ptr-ref!]
+    pcm            [float32-ptr-ptr!]
+    pcmret         [float32-ptr-ptr!]
     pcm_storage    [integer!]
     pcm_current    [integer!]
     pcm_returned   [integer!]
@@ -110,7 +110,7 @@ vorbis_block!: alias struct! [
     ;that logical bitstream.
 
     ;necessary stream state for linking to the framing abstraction
-    pcm          [float32-ptr-ref!] ;this is a pointer into local storage
+    pcm          [float32-ptr-ptr!] ;this is a pointer into local storage
     opb          [oggpack_buffer! value]
 
     lW           [integer!]
@@ -191,8 +191,8 @@ ovectl_ratemanage2_arg!: alias struct! [
 ]
 
 #enum encctlcodes! [
-    ; These values are passed as the \c number parameter of vorbis_encode_ctl().
-    ; The type of the referent of that function's \c arg pointer depends on these
+    ; These values are passed as the number parameter of `vorbis_encode_ctl`.
+    ; The type of the referent of that function's arg pointer depends on these
     ; codes.
 
     ; Query the current encoder bitrate management setting
@@ -327,7 +327,7 @@ ovectl_ratemanage2_arg!: alias struct! [
         vorbis_analysis_buffer: "vorbis_analysis_buffer" [
             v [vorbis_dsp_state!]
             vals [integer!]
-            return: [float32-ptr-ref!]
+            return: [float32-ptr-ptr!]
         ]
         vorbis_analysis_wrote: "vorbis_analysis_wrote" [
             v [vorbis_dsp_state!]

--- a/Library/mpg123/mpg123.reds
+++ b/Library/mpg123/mpg123.reds
@@ -13,7 +13,7 @@ Red/System [
 	#default  [ #define MPG123_LIBRARY "libmpg123.so" ] ;@@ not tested!
 ]
 
-string-ref!:  alias struct! [value [c-string!]]
+#include %../os/definitions.reds ;common aliases and defines
 
 #define mpg123! int-ptr!
 

--- a/Library/os/definitions.reds
+++ b/Library/os/definitions.reds
@@ -40,6 +40,7 @@ string-ptr-ptr!:  alias struct! [value [string-ptr!]]
 handle-ptr!:      alias struct! [value [pointer! [integer!]]]
 logic-ptr!:       alias struct! [value [logic!]]
 int64-ptr!:       alias struct! [value [int64-value!]]
+float32-ptr-ptr!: alias struct! [value [float32-ptr!]]
 
 #if OS = 'Windows  [
 	#define HDC!                      handle!


### PR DESCRIPTION
Also using common definitions file for all libraries so they could be used together without re-definitions.