### PR TITLE
FIX: Stream-IO-test.reds for Linux

### DIFF
--- a/Library/Stream-IO/examples/Stream-IO-test.reds
+++ b/Library/Stream-IO/examples/Stream-IO-test.reds
@@ -23,7 +23,10 @@ Red/System [
 #include %../Stream-IO-read.reds
 #include %../Stream-IO-write.reds
 
-name: #u16 "test-io.bin"
+#either OS = 'Linux [
+    name: "test-io.bin" ][
+    name: #u16 "test-io.bin" 
+]
 file: simple-io/open-file name 0 true
 print-line ["file handle: " as int-ptr! file]
 


### PR DESCRIPTION
When compiled for Linux and run on it, the test does not produce a test-oi.bin file but a file named "t".
It is obvious that the way of using directive #16  (variable name: #u16 "test-io.bin")  is not suitable for Linux. 
After removing directive #u16 the mentioned file is produced with the full name. 
I couldn't have found a better solution with my novice experience.